### PR TITLE
docs(deployment): backport caddyfile/lifecycle/ssh-tunnel guidance from helmio review

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ When Spiderly code changes affect public API, attributes, generated output, or b
 ## Coding conventions
 
 - Prefer raw string literals (`$$""" """`) for multiline strings in C#
-- Enum types follow the `...Codes` naming convention (e.g., `StatusCodes`, `UIControlTypeCodes`)
+- Enum types are conventionally named with a `...Codes` suffix (e.g., `StatusCodes`, `UIControlTypeCodes`) — convention only, not enforced; `[SpiderlyEnum]` is what marks an enum for code generation
 - `bool?` (nullable) is **recommended** for checkbox properties — non-nullable `bool` is supported but `bool?` is preferred in most cases. Treat `null` as `false` in business logic
 - All public members in shipped packages (`Spiderly.Shared`, `Spiderly.Security`, `Spiderly.Infrastructure`) must have `/// <summary>` XML doc comments — never plain `//` comments as documentation. Generated methods that end users can override (virtual hooks) should also include `<example>` showing usage
 - **Database table names are singular** — matching the entity class name exactly (e.g., `Category` class → `"Category"` table, not `"Categories"`). This is because Spiderly registers entities via `modelBuilder.Entity()` without `DbSet<T>` properties, so EF Core uses the class name as-is

--- a/Spiderly.Infrastructure/EntityTypeDiscovery.cs
+++ b/Spiderly.Infrastructure/EntityTypeDiscovery.cs
@@ -10,17 +10,13 @@ namespace Spiderly.Infrastructure
     public static class EntityTypeDiscovery
     {
         /// <summary>
-        /// Returns all entity types from loaded assemblies whose namespace ends with ".Entities"
-        /// and that inherit from BusinessObject/ReadonlyObject or are marked with [M2M].
+        /// Returns all types from loaded assemblies marked with [SpiderlyEntity].
         /// </summary>
         public static List<Type> GetAllEntityTypes()
         {
             return AppDomain.CurrentDomain.GetAssemblies()
                 .SelectMany(a => a.GetTypes())
-                .Where(t =>
-                    t.Namespace != null &&
-                    t.Namespace.EndsWith(".Entities") &&
-                    (t.IsBusinessOrReadonlyEntity() || t.IsDefined(typeof(M2MAttribute), true)))
+                .Where(t => t.IsDefined(typeof(SpiderlyEntityAttribute), inherit: false))
                 .ToList();
         }
     }

--- a/Spiderly.Infrastructure/Extensions.cs
+++ b/Spiderly.Infrastructure/Extensions.cs
@@ -5,7 +5,6 @@ using System.Reflection;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Spiderly.Shared.Extensions;
-using Spiderly.Shared.BaseEntities;
 using Spiderly.Shared.Interfaces;
 
 namespace Spiderly.Infrastructure
@@ -154,26 +153,6 @@ namespace Spiderly.Infrastructure
                 return scalarPointingBack.Name;
 
             return $"{navigation.Name}Id";
-        }
-
-        public static bool IsBusinessOrReadonlyEntity(this Type type)
-        {
-            for (Type? current = type; current != null; current = current.BaseType)
-            {
-                if (
-                    current == typeof(BusinessObject<byte>) ||
-                    current == typeof(BusinessObject<int>) ||
-                    current == typeof(BusinessObject<long>) ||
-                    current == typeof(ReadonlyObject<byte>) ||
-                    current == typeof(ReadonlyObject<int>) ||
-                    current == typeof(ReadonlyObject<long>)
-                )
-                {
-                    return true;
-                }
-            }
-
-            return false;
         }
 
         private static bool IsM2MEntity(this Type type)

--- a/Spiderly.Shared/Extensions/ApplicationDbContextExtensions.cs
+++ b/Spiderly.Shared/Extensions/ApplicationDbContextExtensions.cs
@@ -39,7 +39,20 @@ namespace Spiderly.Shared.Extensions
                 T result = await action();
 
                 if (isFirstTransaction)
+                {
+                    // Loud guard against the "added entities to the tracker but forgot to
+                    // SaveChanges before returning" footgun. transaction.CommitAsync() does
+                    // NOT flush the change tracker — it only commits the DB transaction —
+                    // so silent dropped writes are otherwise possible (e.g. an outbox row
+                    // added after the last SaveChangesAsync that never reaches the DB).
+                    if (context.ChangeTracker.HasChanges())
+                        throw new InvalidOperationException(
+                            "WithTransactionAsync: pending tracked changes at commit. " +
+                            "Call SaveChangesAsync before returning from the action, or " +
+                            "discard/detach the entries you don't intend to persist.");
+
                     await transaction.CommitAsync();
+                }
 
                 return result;
             }
@@ -87,7 +100,20 @@ namespace Spiderly.Shared.Extensions
                 await action();
 
                 if (isFirstTransaction)
+                {
+                    // Loud guard against the "added entities to the tracker but forgot to
+                    // SaveChanges before returning" footgun. transaction.CommitAsync() does
+                    // NOT flush the change tracker — it only commits the DB transaction —
+                    // so silent dropped writes are otherwise possible (e.g. an outbox row
+                    // added after the last SaveChangesAsync that never reaches the DB).
+                    if (context.ChangeTracker.HasChanges())
+                        throw new InvalidOperationException(
+                            "WithTransactionAsync: pending tracked changes at commit. " +
+                            "Call SaveChangesAsync before returning from the action, or " +
+                            "discard/detach the entries you don't intend to persist.");
+
                     await transaction.CommitAsync();
+                }
             }
             catch
             {

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -3114,7 +3114,7 @@ namespace {{appName}}.Business.DataMappers
         "@angular-devkit/build-angular": "19.2.13",
         "@angular/cli": "19.2.13",
         "@angular/compiler-cli": "19.2.13",
-        "@jsverse/transloco-keys-manager": "5.1.0",
+        "@jsverse/transloco-keys-manager": "6.2.2",
         "@playwright/test": "1.49.1",
         "@types/jasmine": "5.1.0",
         "@types/node": "22.10.5",

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -446,6 +446,7 @@ namespace Spiderly.Shared.Helpers
                             new SpiderlyFile { Name = "appsettings.json", Data = GetAppSettingsJsonData(appName) },
                             new SpiderlyFile { Name = "appsettings.Development.json", Data = GetAppSettingsDevelopmentJsonData(appName) },
                             new SpiderlyFile { Name = "appsettings.Development.local.example.json", Data = GetAppSettingsDevelopmentLocalExampleJsonData() },
+                            new SpiderlyFile { Name = "appsettings.Production.json", Data = GetAppSettingsProductionJsonData() },
                             new SpiderlyFile { Name = $"{appName}.WebAPI.csproj", Data = GetWebAPICsProjData(appName, spiderlyVersion, isRunningFromNuget, dbProvider) },
                             new SpiderlyFile { Name = $"{appName}.WebAPI.csproj.user", Data = GetWebAPICsProjUserData() },
                             new SpiderlyFile { Name = "Program.cs", Data = GetProgramCsData(appName) },
@@ -2023,6 +2024,9 @@ public class Startup
         services.AddHangfireServer();
         services.AddSingleton<INotificationDispatcher, HangfireNotificationDispatcher>();
 
+        services.AddHealthChecks()
+            .AddDbContextCheck<{{appName}}ApplicationDbContext>();
+
         services.AddSpiderly<{{appName}}ApplicationDbContext>(spiderly =>
         {
             spiderly.{{(dbProvider == DbProviderCodes.SQLServer ? "UseSQLServer()" : "UsePostgreSQL()")}};
@@ -2035,6 +2039,7 @@ public class Startup
             spiderly.AddFileStorage<DiskStorageService>();
             spiderly.AddSwagger();
             spiderly.AddRateLimiting();
+            spiderly.AddForwardedHeaders();
         });
 
         services.AddAppServices();
@@ -2042,6 +2047,8 @@ public class Startup
 
     public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     {
+        app.SpiderlyConfigureForwardedHeaders();
+
         app.UseCors(builder =>
         {
             builder
@@ -2086,8 +2093,8 @@ public class Startup
 
         app.UseEndpoints(endpoints =>
         {
-            endpoints
-                .MapControllers();
+            endpoints.MapHealthChecks("/health");
+            endpoints.MapControllers();
         });
     }
 }
@@ -2167,6 +2174,7 @@ namespace {{appName}}.WebAPI
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="9.0.1" />
+		<PackageReference Include="Microsoft.Extensions.Diagnostics.HealthChecks.EntityFrameworkCore" Version="9.0.1" />
 		{{(dbProvider == DbProviderCodes.SQLServer ? "<PackageReference Include=\"Microsoft.EntityFrameworkCore.SqlServer\" Version=\"9.0.1\" />" : "<PackageReference Include=\"Npgsql.EntityFrameworkCore.PostgreSQL\" Version=\"9.0.1\" />")}}
 		<PackageReference Include="Hangfire.AspNetCore" Version="1.8.*" />
 		{{(dbProvider == DbProviderCodes.SQLServer ? "<PackageReference Include=\"Hangfire.SqlServer\" Version=\"1.8.*\" />" : "<PackageReference Include=\"Hangfire.PostgreSql\" Version=\"1.20.*\" />")}}
@@ -2303,6 +2311,21 @@ namespace {{appName}}.WebAPI
     },
     "Spiderly.Security": {
       "JwtKey": ""
+    }
+  }
+}
+""";
+        }
+
+        private static string GetAppSettingsProductionJsonData()
+        {
+            return $$"""
+{
+  "$schema": "https://raw.githubusercontent.com/filiptrivan/spiderly/main/schemas/appsettings.schema.json",
+  "AppSettings": {
+    "Spiderly.Shared": {
+      // 2 = Cloudflare -> reverse-proxy -> backend; drop to 1 if only one proxy hop. See the Spiderly 'deployment' skill for TrustedProxyNetworks.
+      "ForwardLimit": 2
     }
   }
 }

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -464,6 +464,7 @@ namespace Spiderly.Shared.Helpers
         {
             new SpiderlyFile { Name = ".gitignore", Data = GetGitIgnoreData() },
             new SpiderlyFile { Name = "README.md", Data = GetREADMEData(appName, spiderlyVersion) },
+            new SpiderlyFile { Name = "CLAUDE.md", Data = GetClaudeMdData(appName) },
         }
             };
 
@@ -4351,6 +4352,52 @@ export class LayoutComponent {
 This project was generated with [Spiderly CLI](https://github.com/filiptrivan/spiderly/tree/main/Spiderly.CLI) version {{spiderlyVersion}}.
 
 For more information about Spiderly, visit our [documentation](https://www.spiderly.dev/docs/getting-started).
+""";
+        }
+
+        private static string GetClaudeMdData(string appName)
+        {
+            return $$"""
+# {{appName}}
+
+A Spiderly application — .NET 9 backend + Angular 19 admin panel, scaffolded by Spiderly CLI.
+
+## What is Spiderly
+
+Spiderly is a code generator. You define EF Core entities as C# classes decorated with custom attributes; source generators emit DTOs, controllers, services, FluentValidation rules, Mapster mappers, Angular CRUD pages, TypeScript entity classes, validators, and translation entries.
+
+**Hand-written code extends generated base classes.** Generated files are regenerated on every build — never edit them directly. Custom logic lives in entity service overrides, custom controllers, custom DTOs, and override hooks.
+
+## Layout
+
+- `Backend/` — .NET 9 solution
+  - `{{appName}}.WebAPI` — ASP.NET host
+  - `{{appName}}.Business` — entity services (`{Entity}Service : {Entity}ServiceGenerated`), hand-written DTOs, business logic
+  - `{{appName}}.Infrastructure` — `EntityModels/` (entity classes), DbContext, EF migrations
+  - `{{appName}}.Migrations` — lightweight startup project for `dotnet ef` (avoids DLL locking when the WebAPI is running)
+- `Frontend/` — Angular 19 SPA (admin panel)
+  - `src/app/business/entities` — generated TypeScript entity classes
+  - `src/app/business/components` — generated and custom CRUD pages
+  - `src/app/business/services` — API service, auth service, layout service
+- `tests/e2e/` — Playwright end-to-end tests
+
+## Key conventions
+
+- **Classification attributes are required** on hand-written classes (source generators enroll by attribute, not namespace):
+  - Entities → `[SpiderlyEntity]`
+  - M2M junctions → `[M2M]` **and** `[SpiderlyEntity]`
+  - Custom controllers → `[SpiderlyController]`
+  - Hand-written DTOs → `[SpiderlyDTO]`
+  - Entity services extending the generated base → `[SpiderlyService]`
+  - Hand-written partial mapper class → `[SpiderlyDataMapper]`
+  - C# enums / class-based string-constant enums exposed to Angular → `[SpiderlyEnum]`
+- **Database table names are singular** — match the entity class name exactly (`Category` class → `"Category"` table).
+- **`bool?` is preferred** over non-nullable `bool` for checkbox properties; treat `null` as `false`.
+- **EF migrations**: run `dotnet ef` commands from `Backend/{{appName}}.Migrations/` as the startup project.
+
+## Working with Claude Code
+
+This project ships with `.claude/settings.json` that auto-enables the **`spiderly@spiderly`** plugin. The plugin contributes trigger-based skills for deeper tasks — entity design, EF migrations, backend hooks, custom endpoints, mapper customization, filtering, file storage, authorization, Angular customization, deployment. Run `/skills` to list. They load on demand, so this file stays small.
 """;
         }
 

--- a/Spiderly.Shared/Interfaces/IApplicationDbContext.cs
+++ b/Spiderly.Shared/Interfaces/IApplicationDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.ChangeTracking;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace Spiderly.Shared.Interfaces
@@ -10,5 +11,13 @@ namespace Spiderly.Shared.Interfaces
         Task<int> SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken));
 
         DatabaseFacade Database { get; }
+
+        /// <summary>
+        /// Exposes the underlying EF Core <see cref="ChangeTracker"/> so callers (notably
+        /// <c>WithTransactionAsync</c>) can detect pending tracked changes at commit time
+        /// and surface a missing <c>SaveChangesAsync</c> as a loud failure rather than a
+        /// silent dropped write.
+        /// </summary>
+        ChangeTracker ChangeTracker { get; }
     }
 }

--- a/Spiderly.SourceGenerators/Angular/BaseDetails/NgBaseDetailsGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/BaseDetails/NgBaseDetailsGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System.IO;
@@ -31,17 +32,20 @@ namespace Spiderly.SourceGenerators.Angular
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var (classesAndEntitiesAndPath, config) = source;
+                var (combinedSource, enumNames) = source;
+                var (classesAndEntitiesAndPath, config) = combinedSource;
                 var (classesAndEntities, callingPath) = classesAndEntitiesAndPath;
                 var (classes, referencedClasses) = classesAndEntities;
 
-                Execute(classes, referencedClasses, callingPath, config, spc);
+                Execute(classes, referencedClasses, enumNames, callingPath, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -49,7 +53,7 @@ namespace Spiderly.SourceGenerators.Angular
             if (!config.IsGeneratorEnabled(nameof(NgBaseDetailsGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
 
             if (currentProjectClasses.Count == 0)
                 return;

--- a/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsDataGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsDataGenerator.cs
@@ -389,7 +389,7 @@ namespace Spiderly.SourceGenerators.Angular
             if (property.HasGenerateCommaSeparatedDisplayNameAttribute())
                 return "multiselect";
 
-            if (property.Type.IsManyToOneType())
+            if (property.IsManyToOneType())
                 return "text";
 
             switch (property.Type)

--- a/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsPropertyBlockGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsPropertyBlockGenerator.cs
@@ -129,7 +129,12 @@ namespace Spiderly.SourceGenerators.Angular
             if (property.IsBlob())
                 return UIControlTypeCodes.File;
 
-            if (property.Type.IsManyToOneType())
+            // Enum-typed entity properties render as a dropdown bound to the TS enum (no API round-trip).
+            // Must come before the M2O check because IsEnum short-circuits IsManyToOneType for the same property.
+            if (property.IsEnum)
+                return UIControlTypeCodes.Dropdown;
+
+            if (property.IsManyToOneType())
                 return UIControlTypeCodes.Autocomplete;
 
             if (property.HasSimpleManyToManyTableLazyLoadAttribute())
@@ -212,7 +217,11 @@ namespace Spiderly.SourceGenerators.Angular
 
         internal static string GetFormControlName(SpiderlyProperty property)
         {
-            if (property.Type.IsManyToOneType())
+            // Enum-typed properties bind directly to the property name (the DTO field is the enum value, not a synthesized FK).
+            if (property.IsEnum)
+                return property.Name.FirstCharToLower();
+
+            if (property.IsManyToOneType())
                 return $"{property.Name.FirstCharToLower()}Id";
 
             if (property.IsMultiSelectControlType())
@@ -372,7 +381,7 @@ namespace Spiderly.SourceGenerators.Angular
             string junctionFormGroupVar = $"{junctionEntity.Name.FirstCharToLower()}FormGroup";
 
             List<SpiderlyProperty> additionalFields = junctionEntity.Properties
-                .Where(p => !p.Type.IsManyToOneType() && !p.Type.IsOneToManyType() && !p.HasUIDoNotGenerateAttribute())
+                .Where(p => !p.IsManyToOneType() && !p.Type.IsOneToManyType() && !p.HasUIDoNotGenerateAttribute())
                 .ToList();
 
             StringBuilder fieldsHtml = new();

--- a/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
@@ -95,7 +95,7 @@ export class ApiGeneratedService extends ApiSecurityService {
         super(http, config);
     }
 
-{{string.Join("\n\n", GetAngularHttpMethods(controllerClasses, allEntities, referencedDTOs, knownTsTypes, context))}}
+{{string.Join("\n\n", GetAngularHttpMethods(controllerClasses, allEntities, referencedDTOs, knownTsTypes, spiderlyEnumNames, context))}}
 
 }
 """;
@@ -103,7 +103,7 @@ export class ApiGeneratedService extends ApiSecurityService {
             Helpers.WriteToTheFile(result, outputPath);
         }
 
-        private static List<string> GetAngularHttpMethods(List<SpiderlyClass> controllerClasses, List<SpiderlyClass> allEntities, List<SpiderlyClass> referencedDTOs, HashSet<string> knownTsTypes, SourceProductionContext context)
+        private static List<string> GetAngularHttpMethods(List<SpiderlyClass> controllerClasses, List<SpiderlyClass> allEntities, List<SpiderlyClass> referencedDTOs, HashSet<string> knownTsTypes, ImmutableArray<string> spiderlyEnumNames, SourceProductionContext context)
         {
             List<string> result = new();
             // Methods already defined in ApiSecurityService (Angular). Keep this list in sync
@@ -138,18 +138,18 @@ export class ApiGeneratedService extends ApiSecurityService {
                     if (!alreadyAddedMethods.Add(controllerMethod.Name))
                         continue;
 
-                    ValidateControllerType(context, "return", controllerMethod.ReturnType, controllerClass.Name, controllerMethod.Name, knownTsTypes, controllerMethod.Location);
+                    ValidateControllerType(context, "return", controllerMethod.ReturnType, controllerClass.Name, controllerMethod.Name, knownTsTypes, spiderlyEnumNames, controllerMethod.Location);
 
                     foreach (SpiderParameter parameter in controllerMethod.Parameters)
-                        ValidateControllerType(context, $"parameter '{parameter.Name}'", parameter.Type, controllerClass.Name, controllerMethod.Name, knownTsTypes, controllerMethod.Location);
+                        ValidateControllerType(context, $"parameter '{parameter.Name}'", parameter.Type, controllerClass.Name, controllerMethod.Name, knownTsTypes, spiderlyEnumNames, controllerMethod.Location);
 
                     if (controllerMethod.Parameters.Any(x => x.HasFromFormAttribute()) && controllerMethod.Parameters.Any(x => x.Type == "IFormFile") == false)
                     {
-                        result.Add(GetCustomFromFormControllerMethod(controllerMethod, controllerName, referencedDTOs));
+                        result.Add(GetCustomFromFormControllerMethod(controllerMethod, controllerName, referencedDTOs, spiderlyEnumNames));
                     }
                     else
                     {
-                        result.Add(GetCustomAngularControllerMethod(controllerMethod, controllerName));
+                        result.Add(GetCustomAngularControllerMethod(controllerMethod, controllerName, spiderlyEnumNames));
                     }
                 }
             }
@@ -173,6 +173,7 @@ export class ApiGeneratedService extends ApiSecurityService {
             string controllerName,
             string methodName,
             HashSet<string> knownTsTypes,
+            ImmutableArray<string> spiderlyEnumNames,
             Location location)
         {
             if (cSharpType.IsBaseDataType()
@@ -180,10 +181,10 @@ export class ApiGeneratedService extends ApiSecurityService {
                 || cSharpType == "void"
                 || cSharpType.Contains("ActionResult")
                 || cSharpType.Contains("IFormFile")
-                || cSharpType.IsEnum())
+                || cSharpType.IsEnum(spiderlyEnumNames))
                 return;
 
-            string extracted = AngularTypeMapper.ExtractAngularTypeFromGenericCSharpType(cSharpType);
+            string extracted = AngularTypeMapper.ExtractAngularTypeFromGenericCSharpType(cSharpType, spiderlyEnumNames);
 
             if (string.IsNullOrEmpty(extracted))
                 return;
@@ -192,7 +193,7 @@ export class ApiGeneratedService extends ApiSecurityService {
                 ? Helpers.ExtractTypeFromGenericType(extracted)
                 : extracted;
 
-            if (AngularTypeMapper.IsKnownTsScalar(target) || target.IsEnum() || knownTsTypes.Contains(target))
+            if (AngularTypeMapper.IsKnownTsScalar(target) || target.IsEnum(spiderlyEnumNames) || knownTsTypes.Contains(target))
                 return;
 
             context.ReportDiagnostic(Diagnostic.Create(
@@ -239,26 +240,26 @@ import { {{ngType}} } from '../../entities/entities.generated';
 
         #region Custom Angular Controller Method
 
-        private static string GetCustomAngularControllerMethod(SpiderlyMethod controllerMethod, string controllerName)
+        private static string GetCustomAngularControllerMethod(SpiderlyMethod controllerMethod, string controllerName, ImmutableArray<string> spiderlyEnumNames)
         {
-            string angularReturnType = AngularTypeMapper.GetAngularType(controllerMethod.ReturnType);
+            string angularReturnType = AngularTypeMapper.GetAngularType(controllerMethod.ReturnType, spiderlyEnumNames);
 
             HttpTypeCodes httpType = GetHttpType(controllerMethod);
 
             Dictionary<string, string> inputParameters = controllerMethod.Parameters
                 .ToDictionary(
                     x => x.Name,
-                    x => AngularTypeMapper.GetAngularType(x.Type)
+                    x => AngularTypeMapper.GetAngularType(x.Type, spiderlyEnumNames)
                 );
 
-            string httpOptions = GetHttpOptions(controllerMethod);
+            string httpOptions = GetHttpOptions(controllerMethod, spiderlyEnumNames);
 
             return GetAngularControllerMethod(controllerMethod.Name, inputParameters, angularReturnType, httpType, controllerName, httpOptions);
         }
 
-        private static string GetHttpOptions(SpiderlyMethod controllerMethod)
+        private static string GetHttpOptions(SpiderlyMethod controllerMethod, ImmutableArray<string> spiderlyEnumNames)
         {
-            if (AngularTypeMapper.GetAngularType(controllerMethod.ReturnType) == "string")
+            if (AngularTypeMapper.GetAngularType(controllerMethod.ReturnType, spiderlyEnumNames) == "string")
                 return Settings.HttpOptionsText;
 
             if (controllerMethod.ReturnType.Contains("IActionResult"))
@@ -341,11 +342,11 @@ import { {{ngType}} } from '../../entities/entities.generated';
 """;
         }
 
-        private static string GetCustomFromFormControllerMethod(SpiderlyMethod controllerMethod, string controllerName, List<SpiderlyClass> DTOList)
+        private static string GetCustomFromFormControllerMethod(SpiderlyMethod controllerMethod, string controllerName, List<SpiderlyClass> DTOList, ImmutableArray<string> spiderlyEnumNames)
         {
             SpiderParameter parameter = controllerMethod.Parameters.Single();
             SpiderlyClass parameterType = DTOList.Where(x => x.Name == parameter.Type).SingleOrDefault();
-            string angularReturnType = AngularTypeMapper.GetAngularType(controllerMethod.ReturnType);
+            string angularReturnType = AngularTypeMapper.GetAngularType(controllerMethod.ReturnType, spiderlyEnumNames);
 
             return $$"""
     {{controllerMethod.Name.FirstCharToLower()}} = (dto: {{parameter.Type.Replace("DTO", "")}}): Observable<{{angularReturnType}}> => { 

--- a/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -32,17 +33,20 @@ namespace Spiderly.SourceGenerators.Angular
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Controllers },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var (classesAndEntitiesAndPath, config) = source;
+                var (combinedSource, enumNames) = source;
+                var (classesAndEntitiesAndPath, config) = combinedSource;
                 var (classesAndEntities, callingPath) = classesAndEntitiesAndPath;
                 var (classes, referencedClasses) = classesAndEntities;
 
-                Execute(classes, referencedClasses, callingPath, config, spc);
+                Execute(classes, referencedClasses, enumNames, callingPath, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -57,7 +61,7 @@ namespace Spiderly.SourceGenerators.Angular
             string rootPath = callingProjectDirectory.GetRootPath();
             string outputPath = Path.Combine(rootPath, "Frontend", "src", "app", "business", "services", "api", "api.service.generated.ts");
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
 
             List<SpiderlyClass> controllerClasses = currentProjectClasses
                 .Where(x => x.HasSpiderlyControllerAttribute())

--- a/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
@@ -4,6 +4,7 @@ using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.IO;
 using System.Linq;
 using System.Text;
@@ -31,17 +32,20 @@ namespace Spiderly.SourceGenerators.Angular
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var (classesAndEntitiesAndPath, config) = source;
+                var (combinedSource, enumNames) = source;
+                var (classesAndEntitiesAndPath, config) = combinedSource;
                 var (classesAndEntities, callingPath) = classesAndEntitiesAndPath;
                 var (classes, referencedClasses) = classesAndEntities;
 
-                Execute(classes, referencedClasses, callingPath, config, spc);
+                Execute(classes, referencedClasses, enumNames, callingPath, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -49,7 +53,7 @@ namespace Spiderly.SourceGenerators.Angular
             if (!config.IsGeneratorEnabled(nameof(NgEntitiesGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
             List<SpiderlyClass> allClasses = currentProjectClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(currentProjectClasses, allClasses);
 
@@ -151,7 +155,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
                 result.AppendLine($$"""
         {{DTOPropLowerCase}}: {
             type: '{{angularDataType}}',
-            {{(DTOProp.Type.IsManyToOneType() || DTOProp.Type.IsOneToManyType() ? $"get nestedConstructor() {{ return {angularDataType.Replace("[]", "")}; }}," : "")}}
+            {{(DTOProp.IsManyToOneType() || DTOProp.Type.IsOneToManyType() ? $"get nestedConstructor() {{ return {angularDataType.Replace("[]", "")}; }}," : "")}}
             {{(DTOProp.IsSaveBodyMainDTO ? $"isSaveBodyMainDTO: true," : "")}}
         },
 """);

--- a/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgEntitiesGenerator.cs
@@ -65,7 +65,7 @@ namespace Spiderly.SourceGenerators.Angular
             StringBuilder sbImports = new();
             sbImports.Append($$"""
 import { BaseEntity, Filter, FilterRule, FilterSortMeta, Namebook } from 'spiderly';
-{{string.Join("\n", GetEnumPropertyImports(currentProjectDTOClasses))}}
+{{string.Join("\n", GetEnumPropertyImports(currentProjectDTOClasses, spiderlyEnumNames))}}
 
 """);
 
@@ -76,10 +76,10 @@ import { BaseEntity, Filter, FilterRule, FilterSortMeta, Namebook } from 'spider
                 foreach (SpiderlyClass DTOClass in DTOClassGroup) // It can only be 2 here
                     DTOProperties.AddRange(DTOClass.Properties);
 
-                List<string> angularPropertyDefinitions = GetAllAngularPropertyDefinitions(DTOProperties);
+                List<string> angularPropertyDefinitions = GetAllAngularPropertyDefinitions(DTOProperties, spiderlyEnumNames);
                 string angularClassIdentifier = DTOClassGroup.Key.Replace("DTO", "");
 
-                sbImports.Append(string.Join("\n", AngularTypeMapper.GetAngularImports(DTOProperties)));
+                sbImports.Append(string.Join("\n", AngularTypeMapper.GetAngularImports(DTOProperties, spiderlyEnumNames)));
 
                 sb.AppendLine($$"""
 
@@ -101,7 +101,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
     }
 
     static schema = {
-{{GetSchemaProperties(DTOProperties)}}
+{{GetSchemaProperties(DTOProperties, spiderlyEnumNames)}}
     } as const;
 
     static typeName = '{{angularClassIdentifier}}' as const;
@@ -115,7 +115,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
             Helpers.WriteToTheFile(sbImports.ToString(), outputPath);
         }
 
-        private static List<string> GetAllAngularPropertyDefinitions(List<SpiderlyProperty> DTOProperties)
+        private static List<string> GetAllAngularPropertyDefinitions(List<SpiderlyProperty> DTOProperties, ImmutableArray<string> spiderlyEnumNames)
         {
             List<string> result = new();
 
@@ -123,7 +123,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
             {
                 string DTOPropLowerCase = DTOProp.Name.FirstCharToLower();
 
-                string angularDataType = AngularTypeMapper.GetAngularType(DTOProp.Type);
+                string angularDataType = AngularTypeMapper.GetAngularType(DTOProp.Type, spiderlyEnumNames);
                 result.Add($"{DTOPropLowerCase}?: {angularDataType};");
             }
 
@@ -143,14 +143,14 @@ export class {{angularClassIdentifier}} extends BaseEntity
             return result;
         }
 
-        private static string GetSchemaProperties(List<SpiderlyProperty> DTOProperties)
+        private static string GetSchemaProperties(List<SpiderlyProperty> DTOProperties, ImmutableArray<string> spiderlyEnumNames)
         {
             StringBuilder result = new();
 
             foreach (SpiderlyProperty DTOProp in DTOProperties)
             {
                 string DTOPropLowerCase = DTOProp.Name.FirstCharToLower();
-                string angularDataType = AngularTypeMapper.GetAngularType(DTOProp.Type);
+                string angularDataType = AngularTypeMapper.GetAngularType(DTOProp.Type, spiderlyEnumNames);
 
                 result.AppendLine($$"""
         {{DTOPropLowerCase}}: {
@@ -164,7 +164,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
             return result.ToString();
         }
 
-        private static List<string> GetEnumPropertyImports(List<SpiderlyClass> DTOClasses)
+        private static List<string> GetEnumPropertyImports(List<SpiderlyClass> DTOClasses, ImmutableArray<string> spiderlyEnumNames)
         {
             List<string> result = new();
 
@@ -175,7 +175,7 @@ export class {{angularClassIdentifier}} extends BaseEntity
                 foreach (SpiderlyClass DTOClass in DTOClassGroup) // It can only be 2 here
                     DTOProperties.AddRange(DTOClass.Properties);
 
-                foreach (SpiderlyProperty property in DTOProperties.Where(x => x.Type.IsEnum()))
+                foreach (SpiderlyProperty property in DTOProperties.Where(x => x.Type.IsEnum(spiderlyEnumNames)))
                 {
                     if (result.Contains(property.Name) == false)
                     {

--- a/Spiderly.SourceGenerators/Models/SpiderlyProperty.cs
+++ b/Spiderly.SourceGenerators/Models/SpiderlyProperty.cs
@@ -25,6 +25,13 @@ namespace Spiderly.SourceGenerators.Models
 
         public string Description { get; set; }
 
+        /// <summary>
+        /// True when this property's type is a C# enum decorated with <c>[SpiderlyEnum]</c>.
+        /// Set during class analysis when an enum-name set is supplied; defaults to false otherwise.
+        /// Generators consult this to short-circuit M2O classification (an enum is a scalar value, not a navigation property).
+        /// </summary>
+        public bool IsEnum { get; set; }
+
         public List<SpiderlyAttribute> Attributes { get; set; } = new();
     }
 }

--- a/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
@@ -6,6 +6,7 @@ using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
@@ -31,17 +32,20 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Controllers },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO, ClassCategoryCodes.Services });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var (classesAndEntitiesAndPath, config) = source;
+                var (combinedSource, enumNames) = source;
+                var (classesAndEntitiesAndPath, config) = combinedSource;
                 var (classesAndEntities, callingPath) = classesAndEntitiesAndPath;
                 var (classes, referencedClasses) = classesAndEntities;
 
-                Execute(classes, referencedClasses, callingPath, config, spc);
+                Execute(classes, referencedClasses, enumNames, callingPath, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntitiesAndServices, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntitiesAndServices, ImmutableArray<string> spiderlyEnumNames, string callingProjectDirectory, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -52,7 +56,7 @@ namespace Spiderly.SourceGenerators.Net
             if (callingProjectDirectory.Contains(".WebAPI") == false)
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntitiesAndServices);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntitiesAndServices, spiderlyEnumNames);
 
             List<SpiderlyClass> customControllers = currentProjectClasses
                 .Where(x => x.HasSpiderlyControllerAttribute())

--- a/Spiderly.SourceGenerators/Net/EntitiesToDTOGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/EntitiesToDTOGenerator.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
 using Microsoft.CodeAnalysis.Text;
 using Spiderly.SourceGenerators.Shared;
@@ -33,14 +34,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntities, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntities, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -48,7 +52,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(EntitiesToDTOGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntities);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntities, spiderlyEnumNames);
             List<SpiderlyClass> currentProjectEntities = currentProjectClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();
             List<SpiderlyClass> allEntities = currentProjectEntities.Concat(referencedProjectEntities).ToList();
 
@@ -75,7 +79,7 @@ namespace Spiderly.SourceGenerators.Net
             string basePartOfNamespace = Helpers.GetBasePartOfNamespace(namespaceValue);
 
             string result = $$"""
-{{GetUsings()}}
+{{GetUsings(basePartOfNamespace)}}
 
 namespace {{basePartOfNamespace}}.DTO
 {
@@ -163,14 +167,18 @@ namespace {{basePartOfNamespace}}.DTO
             return DTObaseType == null ? "" : $": {DTObaseType}";
         }
 
-        private static string GetUsings()
+        private static string GetUsings(string basePartOfNamespace)
         {
+            // {basePartOfNamespace}.Enums is needed when entity properties are typed as a
+            // [SpiderlyEnum]-decorated enum — the DTO emits the enum type by short name and
+            // would otherwise fail to resolve. Convention: enums always live under .Enums.
             return $$"""
 using Microsoft.AspNetCore.Http;
 using Spiderly.Shared.Attributes.Entity;
 using Spiderly.Shared.DTO;
 using Spiderly.Security.DTO;
 using Spiderly.Shared.Helpers;
+using {{basePartOfNamespace}}.Enums;
 """;
         }
 

--- a/Spiderly.SourceGenerators/Net/ExcelPropertiesGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/ExcelPropertiesGenerator.cs
@@ -58,7 +58,7 @@ namespace Spiderly.SourceGenerators.Net
             string basePartOfNamespace = Helpers.GetBasePartOfNamespace(namespaceValue);
 
             sb.AppendLine($$"""
-using {{basePartOfNamespace}}.DTO;
+{{string.Join("\n", ReferencedAssemblyAnalyzer.GetClassesUsings(currentProjectDTOClasses))}}
 
 namespace {{basePartOfNamespace}}.ExcelProperties
 {

--- a/Spiderly.SourceGenerators/Net/ExcelPropertiesGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/ExcelPropertiesGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Shared;
 using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
@@ -31,14 +32,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO, ClassCategoryCodes.DataMappers },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -46,7 +50,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(ExcelPropertiesGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
             List<SpiderlyClass> allClasses = currentProjectClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(currentProjectClasses, allClasses);
 

--- a/Spiderly.SourceGenerators/Net/FluentValidationGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/FluentValidationGenerator.cs
@@ -59,7 +59,7 @@ namespace Spiderly.SourceGenerators.Net
 
             string result = $$"""
 using FluentValidation;
-using {{basePartOfNamespace}}.DTO;
+{{string.Join("\n", ReferencedAssemblyAnalyzer.GetClassesUsings(currentProjectDTOClasses))}}
 using Spiderly.Shared.FluentValidation;
 
 namespace {{basePartOfNamespace}}.ValidationRules

--- a/Spiderly.SourceGenerators/Net/FluentValidationGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/FluentValidationGenerator.cs
@@ -6,6 +6,7 @@ using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
@@ -32,14 +33,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -47,7 +51,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(FluentValidationGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
             List<SpiderlyClass> allClasses = currentProjectClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(currentProjectClasses, allClasses);
             List<SpiderlyClass> currentProjectEntities = currentProjectClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();

--- a/Spiderly.SourceGenerators/Net/MapperGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/MapperGenerator.cs
@@ -50,6 +50,7 @@ namespace Spiderly.SourceGenerators.Net
             List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
             List<SpiderlyClass> allClasses = currentProjectClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectEntities = currentProjectClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();
+            List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(currentProjectClasses, allClasses);
 
             SpiderlyClass customMapperClass = Helpers.GetManualyWrittenMapperClass(currentProjectClasses);
 
@@ -61,7 +62,7 @@ namespace Spiderly.SourceGenerators.Net
             sb.AppendLine($$"""
 using Mapster;
 using Microsoft.AspNetCore.Http;
-using {{basePartOfNamespace}}.DTO;
+{{string.Join("\n", ReferencedAssemblyAnalyzer.GetClassesUsings(currentProjectDTOClasses))}}
 using {{basePartOfNamespace}}.Entities;
 
 namespace {{basePartOfNamespace}}.DataMappers

--- a/Spiderly.SourceGenerators/Net/MapperGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/MapperGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Shared;
 using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 using System;
@@ -32,14 +33,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DataMappers },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DataMappers });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -47,7 +51,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(MapperGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
             List<SpiderlyClass> allClasses = currentProjectClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectEntities = currentProjectClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();
             List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(currentProjectClasses, allClasses);
@@ -213,7 +217,7 @@ namespace {{basePartOfNamespace}}.DataMappers
 
             foreach (SpiderlyProperty property in entity.Properties)
             {
-                if (property.Type.IsManyToOneType())
+                if (property.IsManyToOneType())
                 {
                     SpiderlyClass manyToOneEntity = entities
                         .Where(x => x.Name == property.Type)

--- a/Spiderly.SourceGenerators/Net/PaginatedResultGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/PaginatedResultGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
@@ -33,14 +34,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO, ClassCategoryCodes.DataMappers },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.DTO });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectClasses, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -48,7 +52,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(PaginatedResultGenerator)))
                 return;
 
-            List<SpiderlyClass> spiderlyClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses);
+            List<SpiderlyClass> spiderlyClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectClasses, spiderlyEnumNames);
             List<SpiderlyClass> allClasses = spiderlyClasses.Concat(referencedProjectClasses).ToList();
             List<SpiderlyClass> currentProjectDTOClasses = SpiderlyClassFactory.GetDTOClasses(spiderlyClasses, allClasses);
             List<SpiderlyClass> currentProjectEntities = spiderlyClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();
@@ -343,7 +347,7 @@ using {{item}};
 
         private static string GetCaseForNumber(string DTOIdentifier, string entityDotNotation, string numberType)
         {
-            string numberTypeWithoutQuestion = numberType.Replace("?", "");
+            string numberTypeWithoutQuestion = numberType.WithoutNullableSuffix();
 
             return $$"""
                             case "{{DTOIdentifier.FirstCharToLower()}}":

--- a/Spiderly.SourceGenerators/Net/Services/ServiceDeleteGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceDeleteGenerator.cs
@@ -29,11 +29,13 @@ namespace Spiderly.SourceGenerators.Net
 
             return $$"""
         /// <summary>
-        /// Lifecycle hook called before deleting a {{entity.Name}} entity.
-        /// Override this to add custom validation or business logic before deletion.
+        /// Per-id variant of the pre-delete hook. By default forwards to
+        /// <see cref="OnBefore{{entity.Name}}ListDelete"/> with a one-element list, so override
+        /// only the list hook unless single-id and batch flows genuinely diverge.
         /// </summary>
         /// <param name="id">The ID of the entity being deleted</param>
-        public virtual async Task OnBefore{{entity.Name}}Delete({{entityIdType}} id) { }
+        public virtual Task OnBefore{{entity.Name}}Delete({{entityIdType}} id) =>
+            OnBefore{{entity.Name}}ListDelete(id.StructToList());
 
         /// <summary>
         /// Deletes a single {{entity.Name}} entity with cascade delete handling for dependent entities.

--- a/Spiderly.SourceGenerators/Net/Services/ServiceOneToManyGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceOneToManyGenerator.cs
@@ -383,7 +383,7 @@ namespace Spiderly.SourceGenerators.Net
             string otherSideFKName = $"{otherSideM2MProperty.Name}Id";
 
             List<SpiderlyProperty> additionalFields = junctionEntity.Properties
-                .Where(p => !p.Type.IsManyToOneType() && !p.Type.IsOneToManyType())
+                .Where(p => !p.IsManyToOneType() && !p.Type.IsOneToManyType())
                 .ToList();
 
             StringBuilder additionalFieldMappings = new();

--- a/Spiderly.SourceGenerators/Net/Services/ServiceSaveGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceSaveGenerator.cs
@@ -426,7 +426,7 @@ namespace Spiderly.SourceGenerators.Net
             List<string> result = new();
 
             List<SpiderlyProperty> properties = entityClass.Properties
-                .Where(prop => prop.Type.IsManyToOneType())
+                .Where(prop => prop.IsManyToOneType())
                 .ToList();
 
             foreach (SpiderlyProperty prop in properties)

--- a/Spiderly.SourceGenerators/Net/Services/ServicesGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServicesGenerator.cs
@@ -5,6 +5,7 @@ using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text;
 
@@ -25,14 +26,17 @@ namespace Spiderly.SourceGenerators.Net
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities, ClassCategoryCodes.Services },
                 new List<ClassCategoryCodes> { ClassCategoryCodes.Entities });
 
-            context.RegisterSafeImplementationSourceOutput(combined, static (spc, source) =>
+            var combinedWithEnums = combined.Combine(PipelineFactory.GetSpiderlyEnumNamesProvider(context.SyntaxProvider));
+
+            context.RegisterSafeImplementationSourceOutput(combinedWithEnums, static (spc, source) =>
             {
-                var ((classes, referencedClasses), config) = source;
-                Execute(classes, referencedClasses, config, spc);
+                var (combinedSource, enumNames) = source;
+                var ((classes, referencedClasses), config) = combinedSource;
+                Execute(classes, referencedClasses, enumNames, config, spc);
             });
         }
 
-        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntities, SpiderlyConfig config, SourceProductionContext context)
+        private static void Execute(IList<ClassDeclarationSyntax> classes, List<SpiderlyClass> referencedProjectEntities, ImmutableArray<string> spiderlyEnumNames, SpiderlyConfig config, SourceProductionContext context)
         {
             if (classes.Count == 0)
                 return;
@@ -40,7 +44,7 @@ namespace Spiderly.SourceGenerators.Net
             if (!config.IsGeneratorEnabled(nameof(ServicesGenerator)))
                 return;
 
-            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntities);
+            List<SpiderlyClass> currentProjectClasses = SpiderlyClassFactory.GetSpiderlyClasses(classes, referencedProjectEntities, spiderlyEnumNames);
             List<SpiderlyClass> currentProjectEntities = currentProjectClasses.Where(x => x.HasSpiderlyEntityAttribute()).ToList();
             List<SpiderlyClass> allEntities = currentProjectEntities.Concat(referencedProjectEntities).ToList();
 

--- a/Spiderly.SourceGenerators/Shared/AngularTypeMapper.cs
+++ b/Spiderly.SourceGenerators/Shared/AngularTypeMapper.cs
@@ -1,5 +1,6 @@
 using Spiderly.SourceGenerators.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Spiderly.SourceGenerators.Shared
@@ -7,9 +8,10 @@ namespace Spiderly.SourceGenerators.Shared
     public static class AngularTypeMapper
     {
         /// <summary>
-        /// Pass the properties with the C# data types
+        /// Pass the properties with the C# data types. <paramref name="spiderlyEnumNames"/> is the
+        /// <c>[SpiderlyEnum]</c> registry used to decide whether a non-DTO type is an enum.
         /// </summary>
-        public static List<string> GetAngularImports(List<SpiderlyProperty> properties, bool generateClassImports = false, string importPath = null)
+        public static List<string> GetAngularImports(List<SpiderlyProperty> properties, ImmutableArray<string> spiderlyEnumNames, bool generateClassImports = false, string importPath = null)
         {
             List<string> result = new();
 
@@ -18,13 +20,13 @@ namespace Spiderly.SourceGenerators.Shared
                 string cSharpDataType = prop.Type;
                 if (cSharpDataType.IsBaseDataType() == false)
                 {
-                    string angularDataType = GetAngularDataTypeForImport(cSharpDataType);
+                    string angularDataType = GetAngularDataTypeForImport(cSharpDataType, spiderlyEnumNames);
 
                     if (generateClassImports && cSharpDataType.Contains($"{Helpers.DTONamespaceEnding}"))
                     {
                         result.Add($"import {{ {angularDataType} }} from \"./{importPath}entities.generated\";");
                     }
-                    else if (generateClassImports && cSharpDataType.IsEnum())
+                    else if (generateClassImports && cSharpDataType.IsEnum(spiderlyEnumNames))
                     {
                         result.Add($"import {{ {angularDataType} }} from \"../../enums/generated/{importPath}enums.generated\";"); // TODO FT: When you need, implement so you can also send enums from the controller
                     }
@@ -41,7 +43,7 @@ namespace Spiderly.SourceGenerators.Shared
 
         public static bool IsKnownTsScalar(string tsType) => KnownTsScalars.Contains(tsType);
 
-        public static string GetAngularType(string cSharpType)
+        public static string GetAngularType(string cSharpType, ImmutableArray<string> spiderlyEnumNames)
         {
             switch (cSharpType)
             {
@@ -71,33 +73,33 @@ namespace Spiderly.SourceGenerators.Shared
             }
 
             if (cSharpType.IsEnumerable())
-                return $"{ExtractAngularTypeFromGenericCSharpType(cSharpType)}[]";
+                return $"{ExtractAngularTypeFromGenericCSharpType(cSharpType, spiderlyEnumNames)}[]";
 
-            if (cSharpType.IsEnum())
+            if (cSharpType.IsEnum(spiderlyEnumNames))
                 return cSharpType;
 
             if (cSharpType.Contains(Helpers.DTONamespaceEnding) || (cSharpType.Contains("Task<") && cSharpType.Contains("ActionResult") == false)) // FT: We don't want to handle "ActionResult"
-                return ExtractAngularTypeFromGenericCSharpType(cSharpType); // ManyToOne
+                return ExtractAngularTypeFromGenericCSharpType(cSharpType, spiderlyEnumNames); // ManyToOne
 
             return "any"; // eg. "ActionResult", "Task"...
         }
 
-        internal static string GetAngularDataTypeForImport(string CSharpDataType)
+        internal static string GetAngularDataTypeForImport(string CSharpDataType, ImmutableArray<string> spiderlyEnumNames)
         {
             //if (ExtractAngularTypeFromGenericCSharpType(CSharpDataType).IsBaseType()) // TODO FT: We were checking for the C# type, which wasn't correct, but add correct code here if we need in the future
             //    return null;
 
-            if (ExtractAngularTypeFromGenericCSharpType(CSharpDataType).IsEnum())
+            if (ExtractAngularTypeFromGenericCSharpType(CSharpDataType, spiderlyEnumNames).IsEnum(spiderlyEnumNames))
                 return CSharpDataType;
 
-            return ExtractAngularTypeFromGenericCSharpType(CSharpDataType);
+            return ExtractAngularTypeFromGenericCSharpType(CSharpDataType, spiderlyEnumNames);
         }
 
         /// <summary>
         /// cSharp type could be enumerable or class
         /// List<long> -> number
         /// </summary>
-        internal static string ExtractAngularTypeFromGenericCSharpType(string cSharpType)
+        internal static string ExtractAngularTypeFromGenericCSharpType(string cSharpType, ImmutableArray<string> spiderlyEnumNames)
         {
             string result;
 
@@ -127,7 +129,7 @@ namespace Spiderly.SourceGenerators.Shared
             }
             else if (parts[parts.Length - 1].IsBaseDataType())
             {
-                result = GetAngularType(parts[parts.Length - 1]); // List<long>
+                result = GetAngularType(parts[parts.Length - 1], spiderlyEnumNames); // List<long>
             }
             else
             {

--- a/Spiderly.SourceGenerators/Shared/ClassAnalyzer.cs
+++ b/Spiderly.SourceGenerators/Shared/ClassAnalyzer.cs
@@ -3,6 +3,7 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Spiderly.SourceGenerators.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using System.Text.RegularExpressions;
 
@@ -18,11 +19,19 @@ namespace Spiderly.SourceGenerators.Shared
         /// The inherited properties doesn't have any attributes
         /// </summary>
         public static List<SpiderlyProperty> GetAllPropertiesOfTheClass(ClassDeclarationSyntax c, IList<ClassDeclarationSyntax> currentProjectClasses, List<SpiderlyClass> referencedProjectsClasses)
+            => GetAllPropertiesOfTheClass(c, currentProjectClasses, referencedProjectsClasses, ImmutableArray<string>.Empty);
+
+        /// <summary>
+        /// Enum-aware overload. <paramref name="spiderlyEnumNames"/> is the set of <c>[SpiderlyEnum]</c>-decorated enum type names
+        /// in the current compilation; properties whose stringified type matches a name in the set get <c>IsEnum = true</c>.
+        /// Pass <see cref="ImmutableArray{T}.Empty"/> to opt out of enum tagging (legacy behavior).
+        /// </summary>
+        public static List<SpiderlyProperty> GetAllPropertiesOfTheClass(ClassDeclarationSyntax c, IList<ClassDeclarationSyntax> currentProjectClasses, List<SpiderlyClass> referencedProjectsClasses, ImmutableArray<string> spiderlyEnumNames)
         {
             TypeSyntax baseType = c.BaseList?.Types.FirstOrDefault()?.Type; // BaseClass<long>
             ClassDeclarationSyntax baseClass = GetClass(baseType, currentProjectClasses);
 
-            List<SpiderlyProperty> properties = GetPropsOfCurrentClass(c);
+            List<SpiderlyProperty> properties = GetPropsOfCurrentClass(c, spiderlyEnumNames);
 
             TypeSyntax typeGeneric = null;
 
@@ -116,25 +125,44 @@ namespace Spiderly.SourceGenerators.Shared
         /// Without inherited properties
         /// </summary>
         public static List<SpiderlyProperty> GetPropsOfCurrentClass(ClassDeclarationSyntax c)
+            => GetPropsOfCurrentClass(c, ImmutableArray<string>.Empty);
+
+        /// <summary>
+        /// Enum-aware overload. <paramref name="spiderlyEnumNames"/> is the set of <c>[SpiderlyEnum]</c>-decorated enum type names
+        /// in the current compilation; properties whose stringified type matches a name in the set get <c>IsEnum = true</c>.
+        /// </summary>
+        public static List<SpiderlyProperty> GetPropsOfCurrentClass(ClassDeclarationSyntax c, ImmutableArray<string> spiderlyEnumNames)
         {
+            // Build a HashSet once per class scan; ImmutableArray.Contains is O(N).
+            // Nullable enum properties (`OrderStatusCodes?`) need the suffix stripped to match the unadorned name in the set.
+            HashSet<string> enumNameSet = spiderlyEnumNames.IsDefaultOrEmpty
+                ? null
+                : new HashSet<string>(spiderlyEnumNames);
+
             List<SpiderlyProperty> properties = c.Members
                 .OfType<PropertyDeclarationSyntax>()
                 .Where(prop => prop.ExplicitInterfaceSpecifier == null)
-                .Select(prop => new SpiderlyProperty()
+                .Select(prop =>
                 {
-                    Type = prop.Type.ToString(),
-                    Name = prop.Identifier.Text,
-                    StringValue = prop.Initializer?.Value?.ToString()?.Trim('"'), // Trimming because: "\"John\"" --> "John"
-                    EntityName = c.Identifier.Text,
-                    Description = GetXmlDocSummary(prop),
-                    Location = prop.Identifier.GetLocation(),
-                    Attributes = prop.AttributeLists
-                        .SelectMany(x => x.Attributes)
-                        .Select(x =>
-                        {
-                            return GetSpiderAttribute(x);
-                        })
-                        .ToList()
+                    string typeText = prop.Type.ToString();
+
+                    return new SpiderlyProperty()
+                    {
+                        Type = typeText,
+                        Name = prop.Identifier.Text,
+                        StringValue = prop.Initializer?.Value?.ToString()?.Trim('"'), // Trimming because: "\"John\"" --> "John"
+                        EntityName = c.Identifier.Text,
+                        Description = GetXmlDocSummary(prop),
+                        Location = prop.Identifier.GetLocation(),
+                        IsEnum = enumNameSet != null && enumNameSet.Contains(typeText.WithoutNullableSuffix()),
+                        Attributes = prop.AttributeLists
+                            .SelectMany(x => x.Attributes)
+                            .Select(x =>
+                            {
+                                return GetSpiderAttribute(x);
+                            })
+                            .ToList()
+                    };
                 })
                 .ToList();
 

--- a/Spiderly.SourceGenerators/Shared/Extensions.cs
+++ b/Spiderly.SourceGenerators/Shared/Extensions.cs
@@ -4,6 +4,7 @@ using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -265,9 +266,23 @@ namespace Spiderly.SourceGenerators.Shared
         }
 
 
-        public static bool IsEnum(this string type)
+        /// <summary>
+        /// Registry-aware enum check. A type is treated as an enum when its (unwrapped, non-nullable) name
+        /// appears in <paramref name="spiderlyEnumNames"/> — the set of <c>[SpiderlyEnum]</c>-decorated enum
+        /// type names collected by <see cref="PipelineFactory.GetSpiderlyEnumNamesProvider"/>.
+        /// <c>[SpiderlyEnum]</c> is the single source of truth — the type name is irrelevant.
+        /// </summary>
+        public static bool IsEnum(this string type, ImmutableArray<string> spiderlyEnumNames)
         {
-            return type.EndsWith("Codes") || type.EndsWith("Codes>");
+            if (type == null || spiderlyEnumNames.IsDefaultOrEmpty)
+                return false;
+
+            string inner = type.WithoutNullableSuffix();
+            int genericOpen = inner.IndexOf('<');
+            if (genericOpen >= 0)
+                inner = inner.Substring(genericOpen + 1).TrimEnd('>').WithoutNullableSuffix();
+
+            return spiderlyEnumNames.Contains(inner);
         }
 
         public static bool IsBlob(this SpiderlyProperty property)

--- a/Spiderly.SourceGenerators/Shared/Extensions.cs
+++ b/Spiderly.SourceGenerators/Shared/Extensions.cs
@@ -171,6 +171,19 @@ namespace Spiderly.SourceGenerators.Shared
             return true;
         }
 
+        /// <summary>
+        /// Enum-aware overload. A property whose type is a <c>[SpiderlyEnum]</c>-decorated enum is a scalar value,
+        /// not a navigation target — short-circuit M2O classification before falling through to the string-based check.
+        /// Generators that have a <see cref="SpiderlyProperty"/> in scope should prefer this overload.
+        /// </summary>
+        public static bool IsManyToOneType(this SpiderlyProperty property)
+        {
+            if (property.IsEnum)
+                return false;
+
+            return property.Type.IsManyToOneType();
+        }
+
         public static bool IsEnumerable(this string type)
         {
             return type.Contains("List") || type.Contains("IList") || type.Contains("[]");
@@ -239,6 +252,16 @@ namespace Spiderly.SourceGenerators.Shared
         public static bool IsReadonlyObject(this SpiderlyClass c)
         {
             return c.BaseType?.Contains($"{Helpers.ReadonlyObject}<") == true;
+        }
+
+        /// <summary>
+        /// Strips the trailing nullability marker from a stringified type name.
+        /// <c>"int?"</c> -> <c>"int"</c>; <c>"OrderStatusCodes"</c> -> <c>"OrderStatusCodes"</c>.
+        /// Tolerates trailing whitespace from upstream type-syntax stringification.
+        /// </summary>
+        public static string WithoutNullableSuffix(this string typeName)
+        {
+            return typeName?.TrimEnd().TrimEnd('?');
         }
 
 
@@ -349,8 +372,10 @@ namespace Spiderly.SourceGenerators.Shared
 
         public static bool ShouldGenerateAutocompleteControllerMethod(this SpiderlyProperty property)
         {
+            // Enum-typed properties get a static client-side dropdown bound to the TS enum,
+            // so the backend doesn't need to expose an autocomplete endpoint for them.
             if (
-                property.Type.IsManyToOneType() &&
+                property.IsManyToOneType() &&
                 property.Attributes.Any(x => x.Name == "UIControlType") == false
             )
             {
@@ -541,7 +566,7 @@ namespace Spiderly.SourceGenerators.Shared
         /// </example>
         public static string ResolveExplicitForeignKeyName(this SpiderlyProperty navigation, SpiderlyClass entity)
         {
-            if (navigation.Type.IsManyToOneType() == false)
+            if (navigation.IsManyToOneType() == false)
                 return null;
 
             string fkFromNavAttribute = navigation.GetForeignKeyAttributeValue();

--- a/Spiderly.SourceGenerators/Shared/ForeignKeyValidator.cs
+++ b/Spiderly.SourceGenerators/Shared/ForeignKeyValidator.cs
@@ -14,7 +14,7 @@ namespace Spiderly.SourceGenerators.Shared
     {
         public static void ValidateEntity(SpiderlyClass entity, List<SpiderlyClass> allEntities)
         {
-            foreach (SpiderlyProperty navigation in entity.Properties.Where(p => p.Type.IsManyToOneType()))
+            foreach (SpiderlyProperty navigation in entity.Properties.Where(p => p.IsManyToOneType()))
             {
                 ValidateForeignKeyAttributeTargets(navigation, entity);
                 ValidateConventionAmbiguity(navigation, entity);
@@ -110,7 +110,7 @@ namespace Spiderly.SourceGenerators.Shared
                 return;
 
             string targetIdType = targetEntity.GetIdType(allEntities);
-            string fkType = fkProperty.Type.TrimEnd().TrimEnd('?');
+            string fkType = fkProperty.Type.WithoutNullableSuffix();
 
             if (fkType != targetIdType)
             {

--- a/Spiderly.SourceGenerators/Shared/Helpers.cs
+++ b/Spiderly.SourceGenerators/Shared/Helpers.cs
@@ -64,7 +64,7 @@ namespace Spiderly.SourceGenerators.Shared
             return entities
                 .SelectMany(x => x.Properties)
                 .Where(prop =>
-                    prop.Type.IsManyToOneType() &&
+                    prop.IsManyToOneType() &&
                     prop.Attributes.Any(x => x.Name == "CascadeDelete") &&
                     prop.Type == entityName
                 )

--- a/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
@@ -81,6 +81,23 @@ namespace Spiderly.SourceGenerators.Shared
             return IsEnumSyntaxTargetForGeneration(enumDeclaration) ? enumDeclaration : null;
         }
 
+        /// <summary>
+        /// Collects the type names of every <c>[SpiderlyEnum]</c>-decorated enum in the current compilation,
+        /// already projected to <see cref="ImmutableArray{T}"/> so consumers don't re-project per <c>Execute</c>.
+        /// Generators that emit code for entity properties feed this into <see cref="SpiderlyClassFactory.GetSpiderlyClasses"/>
+        /// so enum-typed properties get <c>SpiderlyProperty.IsEnum = true</c> instead of being misclassified as M2O navigation.
+        /// </summary>
+        public static IncrementalValueProvider<ImmutableArray<string>> GetSpiderlyEnumNamesProvider(SyntaxValueProvider syntaxValueProvider)
+        {
+            return syntaxValueProvider
+                .CreateSyntaxProvider(
+                    predicate: static (s, _) => IsEnumSyntaxTargetForGeneration(s),
+                    transform: static (ctx, _) => GetEnumSemanticTargetForGeneration(ctx))
+                .Where(static c => c is not null)
+                .Collect()
+                .Select(static (enums, _) => enums.Select(e => e.Identifier.Text).ToImmutableArray());
+        }
+
         private static bool HasEnumAttribute(EnumDeclarationSyntax enumDeclaration, string attributeName)
         {
             string attributeNameWithSuffix = attributeName + "Attribute";

--- a/Spiderly.SourceGenerators/Shared/ReferencedAssemblyAnalyzer.cs
+++ b/Spiderly.SourceGenerators/Shared/ReferencedAssemblyAnalyzer.cs
@@ -116,6 +116,7 @@ namespace Spiderly.SourceGenerators.Shared
                         Type = propertySymbol.Type.TypeToDisplayString(),
                         Name = propertySymbol.Name,
                         EntityName = type.Name,
+                        IsEnum = IsSpiderlyEnumType(propertySymbol.Type),
                         Attributes = GetAttributesFromReferencedAssemblies(propertySymbol),
                     };
 
@@ -126,6 +127,28 @@ namespace Spiderly.SourceGenerators.Shared
             }
 
             return properties.OrderBy(x => x.Name).ToList();
+        }
+
+        // Mirrors ClassAnalyzer.GetPropsOfCurrentClass's enum tagging for properties
+        // sourced from a referenced assembly: a property whose underlying type is an
+        // enum decorated with [SpiderlyEnum] is a scalar value, not a M2O navigation.
+        // Without this flag, generators that skip enum-typed properties (autocomplete
+        // / dropdown controller methods, DTO M2O field synthesis) misclassify them
+        // and ControllerGenerator throws SPIDERLY011 trying to resolve the "entity".
+        // Handles both <c>EventKind</c> and <c>EventKind?</c> shapes.
+        private static bool IsSpiderlyEnumType(ITypeSymbol type)
+        {
+            if (type is INamedTypeSymbol named
+                && named.OriginalDefinition.SpecialType == SpecialType.System_Nullable_T
+                && named.TypeArguments.Length == 1)
+            {
+                type = named.TypeArguments[0];
+            }
+
+            if (type.TypeKind != TypeKind.Enum)
+                return false;
+
+            return type.GetAttributes().Any(a => a.AttributeClass?.Name == "SpiderlyEnumAttribute");
         }
 
         private static List<SpiderlyAttribute> GetAttributesFromReferencedAssemblies(ISymbol symbol)

--- a/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
@@ -242,7 +242,7 @@ namespace Spiderly.SourceGenerators.Shared
                 }
                 else
                 {
-                    DTOProperties.Add(new SpiderlyProperty { Name = property.Name, Type = GetFormatedDTOPropertyType(property.Type), EntityName = $"{property.EntityName}DTO", Description = property.Description });
+                    DTOProperties.Add(new SpiderlyProperty { Name = property.Name, Type = GetFormatedDTOPropertyType(property.Type), EntityName = $"{property.EntityName}DTO", Description = property.Description, IsEnum = property.IsEnum });
                 }
             }
 

--- a/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
@@ -1,6 +1,7 @@
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Spiderly.SourceGenerators.Models;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 
 namespace Spiderly.SourceGenerators.Shared
@@ -8,6 +9,14 @@ namespace Spiderly.SourceGenerators.Shared
     public static class SpiderlyClassFactory
     {
         public static List<SpiderlyClass> GetSpiderlyClasses(IList<ClassDeclarationSyntax> currentProjectClasses, List<SpiderlyClass> referencedProjectsClasses)
+            => GetSpiderlyClasses(currentProjectClasses, referencedProjectsClasses, ImmutableArray<string>.Empty);
+
+        /// <summary>
+        /// Enum-aware overload. <paramref name="spiderlyEnumNames"/> is the set of <c>[SpiderlyEnum]</c>-decorated enum type names
+        /// in the current compilation; entity properties whose stringified type matches a name in the set get <c>IsEnum = true</c>.
+        /// Pass <see cref="ImmutableArray{T}.Empty"/> to opt out of enum tagging (legacy behavior).
+        /// </summary>
+        public static List<SpiderlyClass> GetSpiderlyClasses(IList<ClassDeclarationSyntax> currentProjectClasses, List<SpiderlyClass> referencedProjectsClasses, ImmutableArray<string> spiderlyEnumNames)
         {
             return currentProjectClasses
                 .Select(x =>
@@ -21,7 +30,7 @@ namespace Spiderly.SourceGenerators.Shared
                         BaseType = x.GetBaseType(),
                         IsAbstract = x.IsAbstract(),
                         Description = ClassAnalyzer.GetXmlDocSummary(x),
-                        Properties = ClassAnalyzer.GetAllPropertiesOfTheClass(x, currentProjectClasses, referencedProjectsClasses),
+                        Properties = ClassAnalyzer.GetAllPropertiesOfTheClass(x, currentProjectClasses, referencedProjectsClasses, spiderlyEnumNames),
                         Attributes = ClassAnalyzer.GetAllAttributesOfTheClass(x, currentProjectClasses, referencedProjectsClasses),
                         Methods = ClassAnalyzer.GetMethodsOfCurrentClass(x),
                         Location = x.Identifier.GetLocation(),
@@ -206,7 +215,7 @@ namespace Spiderly.SourceGenerators.Shared
                 if (property.ShouldSkipPropertyInDTO())
                     continue;
 
-                if (property.Type.IsManyToOneType())
+                if (property.IsManyToOneType())
                 {
                     SpiderlyClass manyToOneClass = entities.SingleOrDefault(x => x.Name == property.Type);
 

--- a/Spiderly.SourceGenerators/Shared/ValidationRuleBuilder.cs
+++ b/Spiderly.SourceGenerators/Shared/ValidationRuleBuilder.cs
@@ -62,7 +62,7 @@ namespace Spiderly.SourceGenerators.Shared
 
         private static string GetRulePropertyName(SpiderlyProperty property, SpiderlyClass entity)
         {
-            if (property.HasWithManyAttribute() && property.Type.IsManyToOneType())  // FT: if it is not base type and not enumerable than it's many to one for sure, and the validation can only be for id to be required
+            if (property.HasWithManyAttribute() && property.IsManyToOneType())  // FT: if it is not base type and not enumerable than it's many to one for sure, and the validation can only be for id to be required
                 return property.ResolveExplicitForeignKeyName(entity) ?? $"{property.Name}Id";
 
             if (property.HasUIOrderedOneToManyAttribute())

--- a/Spiderly.SourceGenerators/Shared/Validations.cs
+++ b/Spiderly.SourceGenerators/Shared/Validations.cs
@@ -55,7 +55,7 @@ namespace Spiderly.SourceGenerators.Shared
 
         private static SpiderlyClass ResolveDisplayNameNavigationTarget(SpiderlyClass currentEntity, SpiderlyProperty property, List<SpiderlyClass> allEntities, out Diagnostic error)
         {
-            if (!property.Type.IsManyToOneType())
+            if (!property.IsManyToOneType())
             {
                 error = Diagnostic.Create(
                     SpiderlyDiagnostics.DisplayNameSegmentNotManyToOne,

--- a/claude-plugins/skills/backend-hooks/SKILL.md
+++ b/claude-plugins/skills/backend-hooks/SKILL.md
@@ -64,9 +64,14 @@ protected virtual async Task OnAfterSave{Entity}AndReturnMainUIFormDTO(
 ### Delete Hooks
 
 ```csharp
-public virtual async Task OnBefore{Entity}Delete({IdType} id) { }
+// Default forwards to OnBefore{Entity}ListDelete with a single-element list.
+public virtual Task OnBefore{Entity}Delete({IdType} id) =>
+    OnBefore{Entity}ListDelete(id.StructToList());
+
 public virtual async Task OnBefore{Entity}ListDelete(List<{IdType}> ids) { }
 ```
+
+**When single and batch deletes need the same logic, override only the list hook** — the single-id path forwards to it automatically. Override the single hook only when the per-id behaviour genuinely diverges from the batch case.
 
 ### Get Hooks
 

--- a/claude-plugins/skills/deployment/SKILL.md
+++ b/claude-plugins/skills/deployment/SKILL.md
@@ -1,0 +1,291 @@
+---
+name: deployment
+description: Deploy a Spiderly project to your own infrastructure with Docker, Caddy, and Terraform. Use when setting up production hosting for the .NET backend and Angular admin, configuring CI/CD, managing TLS with Cloudflare origin certificates, or laying out infrastructure-as-code for a Spiderly app.
+---
+
+# Deployment
+
+Spiderly is Docker-first by design (see `ai-agentic-design`). The recommended production setup is a single VPS running Docker Compose, fronted by Caddy and Cloudflare, with all infrastructure declared in Terraform.
+
+## Recommended stack
+
+| Tier | Choice | Why |
+|---|---|---|
+| Compute | **Hetzner Cloud** (or any VPS) | Predictable monthly cost, full control, no PaaS lock-in |
+| Orchestration | **Docker Compose** | Single-host simplicity; matches Spiderly's Docker-first philosophy |
+| Reverse proxy / TLS | **Caddy v2** | Auto-config from Cloudflare origin certs, simple Caddyfile |
+| DNS / WAF / CDN | **Cloudflare** (orange-cloud) | DDoS protection, origin certs, Turnstile |
+| IaC | **Terraform** | Declarative; one source of truth for VPS + DNS + certs |
+| State backend | **Cloudflare R2** | S3-compatible, free tier, encrypted at rest |
+| Container registry | **GitHub Container Registry (GHCR)** | Free for public/internal repos, native to GitHub Actions |
+| CI/CD | **GitHub Actions** | Build, push, SSH-deploy in one workflow file |
+
+## What to host where
+
+- **.NET Backend** → Hetzner+Docker (recommended)
+- **Angular admin** → Hetzner+Docker, **same VPS** as the backend, served by the same Caddy on a separate subdomain
+- **Next.js storefront (if applicable)** → **Vercel recommended**. Next.js + Vercel gives you ISR, edge caching, image optimization, PPR, and instant preview URLs. Hetzner+Docker for SSR is viable but loses these features. Use Hetzner only if you need a single ops surface.
+
+## Compose stack shape
+
+`Backend/docker-compose.prod.yml` (placed alongside the backend project):
+
+```yaml
+services:
+  caddy:
+    image: caddy:2
+    command: caddy run --config /etc/caddy/Caddyfile --watch
+    ports: ["80:80", "443:443"]
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - ./certs:/etc/caddy/certs:ro
+      - caddy_data:/data
+    depends_on:
+      backend:
+        condition: service_started
+      admin:
+        condition: service_healthy
+    restart: unless-stopped
+
+  backend:
+    image: ${BACKEND_IMAGE}
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ASPNETCORE_HTTP_PORTS: "8080"
+      AppSettings__Spiderly.Shared__ConnectionString: "Host=postgres;Port=5432;Database=${DB_NAME};Username=postgres;Password=${DB_PASSWORD};SSL Mode=Disable;"
+      # ... plus storage / mail / OAuth env vars (see file-storage skill for the storage set)
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    depends_on:
+      postgres: { condition: service_healthy }
+    restart: unless-stopped
+
+  admin:
+    image: ${ADMIN_IMAGE}
+    expose: ["80"]
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost/"]
+      interval: 30s
+      timeout: 5s
+      start_period: 10s
+      retries: 3
+    restart: unless-stopped
+
+  postgres:
+    image: postgres:18
+    environment:
+      POSTGRES_DB: ${DB_NAME}
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+    volumes: [postgres_data:/var/lib/postgresql/data]
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres"]
+      interval: 10s
+      retries: 5
+    restart: unless-stopped
+
+volumes:
+  caddy_data:
+  postgres_data:
+```
+
+**Key points:**
+- Only `caddy` binds host ports. `backend` and `admin` are reachable only on the internal Docker network — Caddy reverse-proxies to them by service name.
+- `caddy.depends_on` uses `condition: service_healthy` for the admin container (so Caddy doesn't 502 before the inner Caddy has bound port 80) but `condition: service_started` for the backend — the backend's `/health` endpoint only goes green after EF migrations and warmup, and gating Caddy on that would block all traffic for 20–30 s on every restart.
+- Image tags come from CI via envsubst (`${BACKEND_IMAGE}`, `${ADMIN_IMAGE}`).
+
+## Caddy site blocks
+
+`Backend/Caddyfile`:
+
+```
+api.<your-domain> {
+    tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin-key.pem
+    reverse_proxy backend:8080
+}
+
+admin.<your-domain> {
+    tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin-key.pem
+    reverse_proxy admin:80
+}
+```
+
+Both subdomains share a single Cloudflare origin cert with both names as SANs (set up in Terraform — see below).
+
+## Angular admin Dockerfile
+
+`Frontend/Dockerfile` (multi-stage Node build → Caddy alpine runtime):
+
+```dockerfile
+FROM node:22-alpine AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+FROM caddy:2-alpine
+COPY --from=build /app/dist/<YourApp>/browser /srv
+COPY Caddyfile /etc/caddy/Caddyfile
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
+    CMD wget -q --spider http://localhost/ || exit 1
+```
+
+`Frontend/Caddyfile` (internal — runs inside the admin container):
+
+```
+:80 {
+    root * /srv
+    encode zstd gzip
+
+    @hashedAssets {
+        path_regexp hashed \.[a-f0-9]{8,}\.(js|css|woff2?|ttf|otf|svg|png|jpg|jpeg|webp|ico)$
+    }
+    header @hashedAssets Cache-Control "public, max-age=31536000, immutable"
+
+    @indexHtml path /index.html
+    header @indexHtml Cache-Control "no-cache, no-store, must-revalidate"
+
+    try_files {path} /index.html
+    file_server
+}
+```
+
+The `try_files {path} /index.html` line is the SPA fallback that lets the Angular router handle deep links.
+
+**Lockfile gotcha:** `npm ci` requires `package.json` and `package-lock.json` to be in sync. If a stale dev-dep pins an older Angular major as a peer (e.g. `@jsverse/transloco-keys-manager` 5.x pins Angular 17 while your project is on Angular 19), `npm ci` fails. Bump the dev-dep to the matching major (e.g. `transloco-keys-manager` 6.x for Angular 19) rather than reaching for `--legacy-peer-deps`.
+
+## Terraform layout
+
+Split files by provider concern; one provider, one or two files:
+
+```
+infrastructure/
+├── main.tf                         # required_providers + state backend
+├── variables.tf
+├── outputs.tf
+├── hetzner-firewall.tf             # firewall, allowed ports
+├── cloudflare-dns.tf               # api/admin A records
+├── cloudflare-origin-cert.tf       # origin CA cert + private key
+└── cloudflare-zone.tf              # zone + headers
+```
+
+`main.tf` providers:
+
+```hcl
+terraform {
+  required_version = ">= 1.5"
+
+  backend "s3" {
+    # Cloudflare R2 — S3-compatible
+    bucket = "<your-app>-terraform-state"
+    key    = "infrastructure/terraform.tfstate"
+    region = "auto"
+    skip_credentials_validation = true
+    skip_metadata_api_check     = true
+    skip_region_validation      = true
+    skip_requesting_account_id  = true
+    skip_s3_checksum            = true
+    endpoints = { s3 = "https://<account-id>.r2.cloudflarestorage.com" }
+  }
+
+  required_providers {
+    cloudflare = { source = "cloudflare/cloudflare", version = "~> 5.0" }
+    hcloud     = { source = "hetznercloud/hcloud", version = "~> 1.49" }
+    tls        = { source = "hashicorp/tls", version = "~> 4.0" }
+  }
+}
+```
+
+Origin cert covering both `api` and `admin` subdomains (`cloudflare-origin-cert.tf`):
+
+```hcl
+resource "tls_private_key" "origin" {
+  algorithm = "RSA"
+  rsa_bits  = 2048
+}
+
+resource "tls_cert_request" "origin" {
+  private_key_pem = tls_private_key.origin.private_key_pem
+
+  subject {
+    common_name  = "<your-domain>"
+    organization = "<YourApp>"
+  }
+
+  dns_names = [
+    "api.<your-domain>",
+    "admin.<your-domain>",
+  ]
+}
+
+resource "cloudflare_origin_ca_certificate" "origin" {
+  csr                = tls_cert_request.origin.cert_request_pem
+  hostnames          = tls_cert_request.origin.dns_names
+  request_type       = "origin-rsa"
+  requested_validity = 5475 # 15 years
+}
+```
+
+Sensitive outputs (`outputs.tf`) so the deploy workflow can pull cert + key into GitHub Secrets:
+
+```hcl
+output "origin_cert" {
+  value     = cloudflare_origin_ca_certificate.origin.certificate
+  sensitive = true
+}
+output "origin_cert_key" {
+  value     = tls_private_key.origin.private_key_pem
+  sensitive = true
+}
+```
+
+Retrieve with `terraform output -raw origin_cert` and paste into a GitHub Secret. **Note:** the API token must have `Origin CA: Edit` scope for `cloudflare_origin_ca_certificate` to work.
+
+## CI/CD
+
+Two workflows — one per deploy unit. Both should share a `concurrency` group so they serialize on the same VPS:
+
+```yaml
+# .github/workflows/deploy-backend.yml
+name: Deploy Backend
+on:
+  push:
+    branches: [main]
+    paths: ['Backend/**', '.github/workflows/deploy-backend.yml']
+
+concurrency:
+  group: <your-app>-deploy
+  cancel-in-progress: false
+
+env:
+  IMAGE_NAME:       ghcr.io/<your-user>/<your-app>-backend
+  ADMIN_IMAGE_NAME: ghcr.io/<your-user>/<your-app>-admin
+```
+
+Steps (typical sequence):
+
+1. **Run tests** (gate the deploy on green tests).
+2. **Build + push image** to GHCR (`docker/build-push-action@v6` with GHA cache).
+3. **SSH key setup** + `ssh-keyscan` to trust the host.
+4. **Run EF migrations** via SSH tunnel to the VPS Postgres port (so prod schema updates before the new backend starts).
+5. **Sync compose + Caddyfile** with `envsubst` to inject image tags + secrets, then `scp` to `/opt/<your-app>/`.
+6. **Deploy**: `ssh ... "docker compose pull backend && docker compose up -d"` (compose's healthcheck-aware deps roll the new container only after the new image is healthy).
+
+The admin workflow is similar but lighter: build → push → ssh → `docker compose pull admin && docker compose up -d admin`. **Don't** restart Caddy after an admin update — Caddy resolves `admin:80` via Docker DNS at request time and picks up the new container automatically.
+
+For migration mechanics (creating migrations, the dedicated `*.Migrations` startup-project pattern, why direct DDL on prod is forbidden), see the `ef-migrations` skill.
+
+## Pitfalls
+
+- **Cookie domain across subdomains.** Set `CookieDomain` to `.<your-domain>` (leading dot) so cookies set by `api.<your-domain>` are accepted by `admin.<your-domain>`. `SameSite=Lax` is the right default for an admin SPA.
+- **`ForwardLimit = 2`.** With Cloudflare → Caddy → backend, your forwarded headers cross two proxies. Set `ForwardLimit = 2` in `appsettings.Production.json` and trust Cloudflare IP ranges (see https://www.cloudflare.com/ips/).
+- **CORS `FrontendUrl`.** The backend's `AppSettings__Spiderly.Shared__FrontendUrl` must point to the admin subdomain, not a build-preview URL. Update it when you cut over from staging hosting.
+- **First deploy ordering.** The backend compose references `${ADMIN_IMAGE}`. On a fresh VPS, that image must exist in GHCR before backend deploys, or the admin service definition fails to pull. Push admin first, or run the admin workflow once before the first backend deploy.
+- **`docker compose up -d` brings up everything.** When a backend deploy uses `up -d` without a service name, it'll also bring up `admin` if it's not running. That's usually desired — but means a backend-only commit can replace the admin container. The healthcheck-gated `depends_on` keeps this safe.
+- **Static assets caching.** Hashed Angular bundles (e.g. `main.abc123.js`) can be cached forever; `index.html` must never cache, or users will get a stale shell after a deploy. The Caddyfile in this skill already handles both cases.
+- **`tls_private_key` lives in Terraform state in cleartext.** R2 encryption-at-rest is bucket-level; anyone with R2 API access (or a leaked state file) can read the key. Scope the R2 token tightly, audit who can pull state, and never copy `terraform.tfstate` to laptops or shared drives. Rotating the cert means a fresh `terraform apply` followed by re-pasting the new outputs into GitHub Secrets — plan a maintenance window.

--- a/claude-plugins/skills/deployment/SKILL.md
+++ b/claude-plugins/skills/deployment/SKILL.md
@@ -100,21 +100,64 @@ volumes:
 
 ## Caddy site blocks
 
-`Backend/Caddyfile`:
+`Backend/Caddyfile` — extracts compression + security headers into a `(common)` snippet so both site blocks stay DRY. Cloudflare also sets some of these (HSTS, Brotli) at its edge, but defense-in-depth at the origin is cheap and keeps origin→Cloudflare bandwidth compressed:
 
 ```
+(common) {
+    encode zstd gzip
+    header {
+        Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+        X-Content-Type-Options nosniff
+        X-Frame-Options DENY
+        Referrer-Policy strict-origin-when-cross-origin
+        -Server
+    }
+}
+
 api.<your-domain> {
+    import common
     tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin-key.pem
     reverse_proxy backend:8080
 }
 
 admin.<your-domain> {
+    import common
     tls /etc/caddy/certs/origin.pem /etc/caddy/certs/origin-key.pem
     reverse_proxy admin:80
 }
 ```
 
 Both subdomains share a single Cloudflare origin cert with both names as SANs (set up in Terraform — see below).
+
+## Backend Dockerfile
+
+`Backend/Dockerfile` (multi-stage SDK build → aspnet runtime):
+
+```dockerfile
+FROM mcr.microsoft.com/dotnet/sdk:9.0.102 AS build
+WORKDIR /src
+COPY ["<YourApp>.WebAPI/<YourApp>.WebAPI.csproj", "<YourApp>.WebAPI/"]
+# ... copy other csprojs, restore, copy source, publish ...
+RUN dotnet publish "<YourApp>.WebAPI/<YourApp>.WebAPI.csproj" -c Release -o /app/publish /p:UseAppHost=false
+
+FROM mcr.microsoft.com/dotnet/aspnet:9.0.1
+WORKDIR /app
+RUN apt-get update && apt-get install -y --no-install-recommends curl && rm -rf /var/lib/apt/lists/*
+COPY --from=publish /app/publish .
+USER app
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "<YourApp>.WebAPI.dll"]
+```
+
+**Pin patch versions** (`9.0.102` SDK, `9.0.1` runtime) — `:9.0` floats and breaks reproducible builds.
+
+**Run as non-root.** The aspnet image ships an `app` user (UID 1654). Add `USER app` after `COPY` for defense-in-depth — limits the blast radius of a container escape and matches the platform's sandbox model.
+
+**Caveat — log volumes:** if you're using a Serilog **File sink** (not just Console) with a Hangfire log-archival job — i.e., the app needs to *write* to `/app/logs` — a Docker named volume mount overlays that path with root-owned storage and `app` can't write. Two options:
+- **Bind mount with chowned host dir** (recommended): `volumes: - /var/log/<your-app>:/app/logs` in compose, plus a one-time `mkdir -p /var/log/<your-app> && chown 1654:1654 /var/log/<your-app>` on the VPS. Bind mounts respect host ownership.
+- **No File sink** (simplest): rely on Console sink + Docker's `json-file` driver (50 MB × 3 files rotation already in compose — see below). Access logs via `docker logs`. Drop the `/app/logs` volume entirely.
+
+Console-only is right for greenfield deploys; file-sink-with-archival is right when you have a long-term log retention requirement and ship to S3/R2.
 
 ## Angular admin Dockerfile
 
@@ -208,6 +251,10 @@ Origin cert covering both `api` and `admin` subdomains (`cloudflare-origin-cert.
 resource "tls_private_key" "origin" {
   algorithm = "RSA"
   rsa_bits  = 2048
+
+  lifecycle {
+    prevent_destroy = true
+  }
 }
 
 resource "tls_cert_request" "origin" {
@@ -229,6 +276,12 @@ resource "cloudflare_origin_ca_certificate" "origin" {
   hostnames          = tls_cert_request.origin.dns_names
   request_type       = "origin-rsa"
   requested_validity = 5475 # 15 years
+
+  lifecycle {
+    prevent_destroy = true
+    # Cloudflare normalizes hostname/CSR ordering server-side; ignore both to avoid spurious recreate.
+    ignore_changes = [hostnames, csr]
+  }
 }
 ```
 
@@ -273,9 +326,9 @@ Steps (typical sequence):
 1. **Run tests** (gate the deploy on green tests).
 2. **Build + push image** to GHCR (`docker/build-push-action@v6` with GHA cache).
 3. **SSH key setup** + `ssh-keyscan` to trust the host.
-4. **Run EF migrations** via SSH tunnel to the VPS Postgres port (so prod schema updates before the new backend starts).
+4. **Run EF migrations** via SSH tunnel to the VPS Postgres port (so prod schema updates before the new backend starts). Open the tunnel with `ssh -o ExitOnForwardFailure=yes -fN -L 5432:127.0.0.1:5432 root@host`, then `trap 'pkill -f "ssh ... -L 5432" || true' EXIT` so the tunnel always closes, then `for i in {1..30}; do nc -z localhost 5432 && break; sleep 1; done` instead of a fixed `sleep` — fixed sleeps race against slow SSH startup.
 5. **Sync compose + Caddyfile** with `envsubst` to inject image tags + secrets, then `scp` to `/opt/<your-app>/`.
-6. **Deploy**: `ssh ... "docker compose pull backend && docker compose up -d"` (compose's healthcheck-aware deps roll the new container only after the new image is healthy).
+6. **Deploy**: `ssh ... "docker compose pull backend && docker compose up -d backend caddy"`. Scope to just the services you're updating — unscoped `up -d` will also bounce admin/postgres on every backend push, which is rarely what you want.
 
 The admin workflow is similar but lighter: build → push → ssh → `docker compose pull admin && docker compose up -d admin`. **Don't** restart Caddy after an admin update — Caddy resolves `admin:80` via Docker DNS at request time and picks up the new container automatically.
 
@@ -321,9 +374,28 @@ For migration mechanics (creating migrations, the dedicated `*.Migrations` start
   ```
 
   When `TrustedProxyNetworks` is unset, Spiderly trusts RFC 1918 private ranges by default — fine for Docker-internal Caddy → backend traffic but **not** for the outermost Cloudflare → Caddy hop, which arrives over public IPs.
+
+  On the Terraform side (Hetzner firewall, etc.), use the **`cloudflare_ip_ranges` data source** instead of a hardcoded list — keeps the firewall in sync with Cloudflare's published ranges automatically:
+
+  ```hcl
+  data "cloudflare_ip_ranges" "this" {}
+
+  resource "hcloud_firewall" "main" {
+    rule {
+      direction  = "in"
+      protocol   = "tcp"
+      port       = "443"
+      source_ips = concat(data.cloudflare_ip_ranges.this.ipv4_cidrs, data.cloudflare_ip_ranges.this.ipv6_cidrs)
+    }
+    # ...
+  }
+  ```
+
+  The .NET `TrustedProxyNetworks` list still has to be hardcoded — there's no equivalent runtime data source short of fetching at startup. The hardcoded list and the Terraform data source describe the same set, so both rot at the same speed; pin a calendar reminder to refresh quarterly.
 - **CORS `FrontendUrl`.** The backend's `AppSettings__Spiderly.Shared__FrontendUrl` must point to the admin subdomain, not a build-preview URL. Update it when you cut over from staging hosting.
 - **First deploy ordering.** The backend compose references `${ADMIN_IMAGE}`. On a fresh VPS, that image must exist in GHCR before backend deploys, or the admin service definition fails to pull. Push admin first, or run the admin workflow once before the first backend deploy.
-- **`docker compose up -d` brings up everything.** When a backend deploy uses `up -d` without a service name, it'll also bring up `admin` if it's not running. That's usually desired — but means a backend-only commit can replace the admin container. The healthcheck-gated `depends_on` keeps this safe.
+- **`docker compose up -d` scoping.** Always scope to the services you're updating: `docker compose up -d backend caddy` for backend deploys, `docker compose up -d admin` for admin deploys. Unscoped `up -d` bounces every service that's currently down or has a config change — including admin and postgres on a backend-only commit. The healthcheck-gated `depends_on` makes the unscoped form *safe* but not *desirable*.
 - **Static assets caching.** Hashed Angular bundles (e.g. `main.abc123.js`) can be cached forever; `index.html` must never cache, or users will get a stale shell after a deploy. The Caddyfile in this skill already handles both cases.
-- **`tls_private_key` lives in Terraform state in cleartext.** R2 encryption-at-rest is bucket-level; anyone with R2 API access (or a leaked state file) can read the key. Scope the R2 token tightly, audit who can pull state, and never copy `terraform.tfstate` to laptops or shared drives. Rotating the cert means a fresh `terraform apply` followed by re-pasting the new outputs into GitHub Secrets — plan a maintenance window.
+- **`tls_private_key` lives in Terraform state in cleartext.** R2 encryption-at-rest is bucket-level; anyone with R2 API access (or a leaked state file) can read the key. Scope the R2 token tightly, audit who can pull state, and never copy `terraform.tfstate` to laptops or shared drives. Rotating the cert means a fresh `terraform apply` followed by re-pasting the new outputs into GitHub Secrets — plan a maintenance window. Add `lifecycle { prevent_destroy = true }` to the `tls_private_key` and `cloudflare_origin_ca_certificate` resources so accidental config changes can't trigger a silent rotation. Also add `ignore_changes = [hostnames, csr]` on the cert — Cloudflare normalizes hostname/CSR ordering server-side, otherwise every plan would show a phantom recreate.
+- **Postgres data on Docker named volumes is not durable across server replacement.** If the VPS itself is Terraform-managed (`hcloud_server`) and gets recreated for any reason — image change, server_type change, accidental destroy — the local Docker named volume `postgres_data` goes with it. Add `lifecycle { prevent_destroy = true }` to the `hcloud_server` resource. For genuine durability, attach an `hcloud_volume` and bind-mount it into postgres (`/var/lib/postgresql/data`); volumes survive server destruction and snapshot independently.
 - **Cloudflare in front of Vercel must stay "DNS only".** When the Next.js storefront (or a Vercel-hosted admin) deploys to Vercel and DNS is on Cloudflare, those records must be **DNS only** (grey cloud), not proxied. Vercel terminates TLS and runs its own edge — CDN, image optimization, ISR, PPR — so adding the Cloudflare proxy on top breaks the TLS handshake and double-caches/conflicts with Vercel's edge features. Cloudflare's WAF/cache/analytics/Turnstile belong on the **Hetzner-served** records (`api.*`, `admin.*`) where the orange cloud stays on. If you want Cloudflare features in front of Vercel anyway, that's an advanced setup ("Full (strict)" SSL + custom hostnames) that Vercel does not officially recommend.

--- a/claude-plugins/skills/deployment/SKILL.md
+++ b/claude-plugins/skills/deployment/SKILL.md
@@ -57,7 +57,8 @@ services:
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:8080/health"]
       interval: 30s
-      timeout: 10s
+      timeout: 5s
+      start_period: 60s
       retries: 3
     depends_on:
       postgres: { condition: service_healthy }
@@ -283,9 +284,46 @@ For migration mechanics (creating migrations, the dedicated `*.Migrations` start
 ## Pitfalls
 
 - **Cookie domain across subdomains.** Set `CookieDomain` to `.<your-domain>` (leading dot) so cookies set by `api.<your-domain>` are accepted by `admin.<your-domain>`. `SameSite=Lax` is the right default for an admin SPA.
-- **`ForwardLimit = 2`.** With Cloudflare → Caddy → backend, your forwarded headers cross two proxies. Set `ForwardLimit = 2` in `appsettings.Production.json` and trust Cloudflare IP ranges (see https://www.cloudflare.com/ips/).
+- **`ForwardLimit = 2`.** With Cloudflare → Caddy → backend, your forwarded headers cross two proxies. The Spiderly scaffold ships `appsettings.Production.json` with `ForwardLimit: 2` already set; if you sit behind Cloudflare, paste the current Cloudflare CIDR list into `TrustedProxyNetworks` (refresh from https://www.cloudflare.com/ips/ periodically — Cloudflare adds ranges occasionally):
+
+  ```json
+  {
+    "AppSettings": {
+      "Spiderly.Shared": {
+        "ForwardLimit": 2,
+        "TrustedProxyNetworks": [
+          "173.245.48.0/20",
+          "103.21.244.0/22",
+          "103.22.200.0/22",
+          "103.31.4.0/22",
+          "141.101.64.0/18",
+          "108.162.192.0/18",
+          "190.93.240.0/20",
+          "188.114.96.0/20",
+          "197.234.240.0/22",
+          "198.41.128.0/17",
+          "162.158.0.0/15",
+          "104.16.0.0/13",
+          "104.24.0.0/14",
+          "172.64.0.0/13",
+          "131.0.72.0/22",
+          "2400:cb00::/32",
+          "2606:4700::/32",
+          "2803:f800::/32",
+          "2405:b500::/32",
+          "2405:8100::/32",
+          "2a06:98c0::/29",
+          "2c0f:f248::/32"
+        ]
+      }
+    }
+  }
+  ```
+
+  When `TrustedProxyNetworks` is unset, Spiderly trusts RFC 1918 private ranges by default — fine for Docker-internal Caddy → backend traffic but **not** for the outermost Cloudflare → Caddy hop, which arrives over public IPs.
 - **CORS `FrontendUrl`.** The backend's `AppSettings__Spiderly.Shared__FrontendUrl` must point to the admin subdomain, not a build-preview URL. Update it when you cut over from staging hosting.
 - **First deploy ordering.** The backend compose references `${ADMIN_IMAGE}`. On a fresh VPS, that image must exist in GHCR before backend deploys, or the admin service definition fails to pull. Push admin first, or run the admin workflow once before the first backend deploy.
 - **`docker compose up -d` brings up everything.** When a backend deploy uses `up -d` without a service name, it'll also bring up `admin` if it's not running. That's usually desired — but means a backend-only commit can replace the admin container. The healthcheck-gated `depends_on` keeps this safe.
 - **Static assets caching.** Hashed Angular bundles (e.g. `main.abc123.js`) can be cached forever; `index.html` must never cache, or users will get a stale shell after a deploy. The Caddyfile in this skill already handles both cases.
 - **`tls_private_key` lives in Terraform state in cleartext.** R2 encryption-at-rest is bucket-level; anyone with R2 API access (or a leaked state file) can read the key. Scope the R2 token tightly, audit who can pull state, and never copy `terraform.tfstate` to laptops or shared drives. Rotating the cert means a fresh `terraform apply` followed by re-pasting the new outputs into GitHub Secrets — plan a maintenance window.
+- **Cloudflare in front of Vercel must stay "DNS only".** When the Next.js storefront (or a Vercel-hosted admin) deploys to Vercel and DNS is on Cloudflare, those records must be **DNS only** (grey cloud), not proxied. Vercel terminates TLS and runs its own edge — CDN, image optimization, ISR, PPR — so adding the Cloudflare proxy on top breaks the TLS handshake and double-caches/conflicts with Vercel's edge features. Cloudflare's WAF/cache/analytics/Turnstile belong on the **Hetzner-served** records (`api.*`, `admin.*`) where the orange cloud stays on. If you want Cloudflare features in front of Vercel anyway, that's an advanced setup ("Full (strict)" SSL + custom hostnames) that Vercel does not officially recommend.

--- a/claude-plugins/skills/entity-design/SKILL.md
+++ b/claude-plugins/skills/entity-design/SKILL.md
@@ -34,6 +34,10 @@ Hand-written DTOs use `[SpiderlyDTO]`. Generated DTOs (`{Entity}DTO`, `{Entity}S
 
 `T` = `long` (default), `int`, or `byte`.
 
+## Operational tables
+
+Tables that exist as operational state (outbox, audit log, sync cursors, dispatcher queues) are still `[SpiderlyEntity]` — do **not** reach for `[UIDoNotGenerate]` at the class level and a parallel custom Angular page; you lose the generated table, mappers, validators, and DTOs for no gain. Restrict mutations by not granting `Insert{Entity}` / `Update{Entity}` / `Delete{Entity}` permissions to any role in your seed setup; default-filter the admin table to "interesting" rows (e.g. pending, failed) via a paginated-list override (see `spiderly:filtering-patterns`); expose semantic row actions like Retry/Dismiss via a custom controller alongside the generated one (see `spiderly:custom-endpoints`).
+
 ## Property Rules
 
 - Navigation properties **must** be `virtual`: `public virtual Brand Brand { get; set; }`


### PR DESCRIPTION
## Summary

Updates the deployment skill template with fixes that surfaced during helmio's first-deploy review and were backported to PACMS in [filiptrivan/pa-cms#31](https://github.com/filiptrivan/pa-cms/pull/31). Future Spiderly projects copying from this skill get the corrected patterns by default.

### Changes (single file: \`claude-plugins/skills/deployment/SKILL.md\`)

- **Caddy site blocks**: extracted compression + security headers into a \`(common)\` snippet imported by both \`api.\` and \`admin.\` blocks (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, hide Server; \`encode zstd gzip\`)
- **New Backend Dockerfile section**: didn't exist before — shows pinned \`9.0.102\`/\`9.0.1\`, \`USER app\` (UID 1654), and the bind-mount-vs-Console-only choice when File sink is in play
- **Origin cert Terraform example**: \`lifecycle.prevent_destroy\` on key + cert; \`ignore_changes = [hostnames, csr]\` on the cert (Cloudflare normalizes SAN/CSR ordering server-side, was triggering phantom recreates)
- **CI/CD steps 4 + 6**: SSH tunnel uses \`ExitOnForwardFailure\` + \`trap\` cleanup + \`nc -z\` poll (replaces racy fixed sleep); deploy is scoped to \`docker compose up -d backend caddy\` instead of unscoped \`up -d\`
- **Pitfall**: \`data.cloudflare_ip_ranges\` data source for Terraform-side firewall rules (auto-syncs with CF's published list); .NET \`TrustedProxyNetworks\` still hardcoded — no equivalent runtime data source
- **Pitfall**: postgres data on Docker named volumes is not durable across \`hcloud_server\` replacement; recommend \`prevent_destroy\` + \`hcloud_volume\` for durability

## Test plan

- [ ] Render via \`/spiderly:deployment\` slash command in a fresh Claude Code session and visually confirm formatting
- [ ] Spot-check the new Backend Dockerfile section reads cleanly with \`<YourApp>\` placeholders

🤖 Generated with [Claude Code](https://claude.com/claude-code)