### PR TITLE
Clean generated app npm dependencies

### DIFF
--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -4140,7 +4140,6 @@ namespace {{appName}}.Business.DataMappers
         "@angular/router": "19.2.13",
         "@jsverse/transloco": "7.5.0",
         "file-saver": "2.0.5",
-        "json-parser": "3.1.2",
         "ngx-spinner": "19.0.0",
         "primeflex": "3.3.1",
         "primeicons": "7.0.0",
@@ -4149,7 +4148,6 @@ namespace {{appName}}.Business.DataMappers
         "quill": "2.0.2",
         "rxjs": "7.8.1",
         "tslib": "2.3.0",
-        "webpack-dev-server": "4.15.1",
         "zone.js": "0.15.1"
     },
     "devDependencies": {


### PR DESCRIPTION
## Summary

- remove the unused direct `json-parser` dependency from the generated frontend `package.json`
- remove the direct `webpack-dev-server` dependency because Angular CLI/build tooling already provides the dev server path
- reduce npm install deprecation noise for apps initialized with `Spiderly.CLI`

## Notes

This intentionally avoids broad Angular/PrimeNG/Karma upgrades. A fresh generated-package install still reports some upstream deprecation warnings from transitive packages such as Karma, Angular CLI tooling, Quill, Transloco, and PrimeNG themes. This PR removes the direct dependencies from Spiderly's generated app template that are either unused or redundant.

## Verification

- Reproduced the generated package install warnings in a temporary generated-package fixture with `npm install --ignore-scripts`.
- Re-ran the same install after removing `json-parser` and direct `webpack-dev-server`; install completed successfully and the direct `json-parser` warning was gone.
- `git diff --check`

I could not run the .NET build locally because `dotnet` is not installed in this environment.

Fixes #3
