### PR TITLE
Use PrimeIcons in generated menus

### DIFF
--- a/Spiderly.CLI/Commands/AddNewEntityCommand.cs
+++ b/Spiderly.CLI/Commands/AddNewEntityCommand.cs
@@ -12,6 +12,8 @@ namespace Spiderly.CLI.Commands
 {
     internal static class AddNewEntityCommand
     {
+        private const string PrimeIconsImport = "import { PrimeIcons } from 'primeng/api';";
+
         public static async Task<int> Execute(bool shouldGenerateDataView, string entityName = null)
         {
             if (string.IsNullOrWhiteSpace(entityName))
@@ -204,10 +206,12 @@ namespace Spiderly.CLI.Commands
                 return true;
             }
 
+            layoutContent = EnsurePrimeIconsImport(layoutContent);
+
             string menuItemToAdd = $$"""
                                 {
                                     label: this.translocoService.translate('{{entityName}}List'),
-                                    icon: 'pi pi-fw pi-list',
+                                    icon: PrimeIcons.LIST,
                                     routerLink: ['/{{kebabEntityName}}-list'],
                                 },
             """;
@@ -246,6 +250,19 @@ namespace Spiderly.CLI.Commands
 
             ConsoleHelper.MarkupLineWARNING("Could not find the appropriate location to insert menu item. Please add it manually.");
             return true;
+        }
+
+        private static string EnsurePrimeIconsImport(string layoutContent)
+        {
+            if (layoutContent.Contains("PrimeIcons", StringComparison.Ordinal))
+                return layoutContent;
+
+            MatchCollection importMatches = Regex.Matches(layoutContent, @"^import .+;$", RegexOptions.Multiline);
+            if (importMatches.Count == 0)
+                return $"{PrimeIconsImport}{Environment.NewLine}{layoutContent}";
+
+            Match lastImport = importMatches[^1];
+            return layoutContent.Insert(lastImport.Index + lastImport.Length, $"{Environment.NewLine}{PrimeIconsImport}");
         }
 
         private static async Task<bool> AddTranslations(string entityName)

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -4231,6 +4231,7 @@ import { FormsModule } from '@angular/forms';
 import { SpiderlyLayoutComponent, SpiderlyMenuItem, SecurityPermissionCodes } from 'spiderly';
 import { CommonModule } from '@angular/common';
 import { PermissionCodes } from '../enums/enums.generated';
+import { PrimeIcons } from 'primeng/api';
 
 @Component({
     selector: 'layout',
@@ -4258,12 +4259,12 @@ export class LayoutComponent {
                 items: [
                     { 
                         label: this.translocoService.translate('Home'), 
-                        icon: 'pi pi-fw pi-home', 
+                        icon: PrimeIcons.HOME,
                         routerLink: [''],
                     },
                     {
                         label: this.translocoService.translate('Administration'),
-                        icon: 'pi pi-fw pi-cog',
+                        icon: PrimeIcons.COG,
                         hasPermission: (permissionCodes: string[]): boolean => {
                             return (
                                 permissionCodes?.includes(PermissionCodes.ReadUser) ||
@@ -4273,7 +4274,7 @@ export class LayoutComponent {
                         items: [
                             {
                                 label: this.translocoService.translate('UserList'),
-                                icon: 'pi pi-fw pi-user',
+                                icon: PrimeIcons.USER,
                                 routerLink: [`/${this.config.administrationSlug}/users`],
                                 hasPermission: (permissionCodes: string[]): boolean => {
                                     return (
@@ -4283,7 +4284,7 @@ export class LayoutComponent {
                             },
                             {
                                 label: this.translocoService.translate('RoleList'),
-                                icon: 'pi pi-fw pi-id-card',
+                                icon: PrimeIcons.ID_CARD,
                                 routerLink: [`/${this.config.administrationSlug}/roles`],
                                 hasPermission: (permissionCodes: string[]): boolean => {
                                     return (


### PR DESCRIPTION
Fixes #56

## Summary
- import `PrimeIcons` in the generated layout component
- use `PrimeIcons` constants for the default generated menu icons
- use `PrimeIcons.LIST` when `spiderly add-new-entity` injects a menu item, adding the import when needed

## Validation
- `git diff --check`
- static review of generated TypeScript import and menu item output

I could not run a local build in this environment because `dotnet` is not installed.