### PR TITLE
Reduce no-op source generator churn on unrelated saves

### DIFF
--- a/Spiderly.SourceGenerators.Tests/HelpersTests.cs
+++ b/Spiderly.SourceGenerators.Tests/HelpersTests.cs
@@ -275,6 +275,52 @@ public class HelpersTests
 
     #endregion
 
+    #region WriteToTheFile
+
+    [Fact]
+    public void WriteToTheFile_SameContent_DoesNotTouchExistingFile()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+        DateTime originalWriteTime = new(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+        try
+        {
+            File.WriteAllText(path, "same content");
+            File.SetLastWriteTimeUtc(path, originalWriteTime);
+
+            Helpers.WriteToTheFile("same content", path);
+
+            Assert.Equal(originalWriteTime, File.GetLastWriteTimeUtc(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    [Fact]
+    public void WriteToTheFile_DifferentContent_UpdatesExistingFile()
+    {
+        string path = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.txt");
+
+        try
+        {
+            File.WriteAllText(path, "old content");
+
+            Helpers.WriteToTheFile("new content", path);
+
+            Assert.Equal("new content", File.ReadAllText(path));
+        }
+        finally
+        {
+            if (File.Exists(path))
+                File.Delete(path);
+        }
+    }
+
+    #endregion
+
     #region Static Properties
 
     [Fact]

--- a/Spiderly.SourceGenerators.Tests/ReferencedAssemblyAnalyzerTests.cs
+++ b/Spiderly.SourceGenerators.Tests/ReferencedAssemblyAnalyzerTests.cs
@@ -86,4 +86,16 @@ public class ReferencedAssemblyAnalyzerTests
 
         Assert.Equal("long", brand.GetIdType(entities));
     }
+
+    [Fact]
+    public void ReferencedAssemblyComparer_TreatsEquivalentMetadataAsEqual()
+    {
+        List<SpiderlyClass> first = GetReferencedEntities();
+        List<SpiderlyClass> second = GetReferencedEntities();
+
+        Assert.True(ReferencedSpiderlyClassListComparer.Instance.Equals(first, second));
+        Assert.Equal(
+            ReferencedSpiderlyClassListComparer.Instance.GetHashCode(first),
+            ReferencedSpiderlyClassListComparer.Instance.GetHashCode(second));
+    }
 }

--- a/Spiderly.SourceGenerators/Shared/Helpers.cs
+++ b/Spiderly.SourceGenerators/Shared/Helpers.cs
@@ -272,6 +272,10 @@ namespace Spiderly.SourceGenerators.Shared
             if (data != null)
             {
                 data = data.Replace("\r\n", "\n").Replace("\n", Environment.NewLine);
+
+                if (File.Exists(path) && File.ReadAllText(path) == data)
+                    return;
+
                 using StreamWriter sw = new StreamWriter(path, false);
                 sw.Write(data);
             }

--- a/Spiderly.SourceGenerators/Shared/ReferencedAssemblyAnalyzer.cs
+++ b/Spiderly.SourceGenerators/Shared/ReferencedAssemblyAnalyzer.cs
@@ -44,7 +44,8 @@ namespace Spiderly.SourceGenerators.Shared
         public static IncrementalValueProvider<List<SpiderlyClass>> GetIncrementalValueProviderClassesFromReferencedAssemblies(IncrementalGeneratorInitializationContext context, List<ClassCategoryCodes> categories)
         {
             return context.CompilationProvider
-                .Select((compilation, _) => GetClassesFromCompilation(compilation, categories));
+                .Select((compilation, _) => GetClassesFromCompilation(compilation, categories))
+                .WithComparer(ReferencedSpiderlyClassListComparer.Instance);
         }
 
         /// <summary>

--- a/Spiderly.SourceGenerators/Shared/ReferencedSpiderlyClassListComparer.cs
+++ b/Spiderly.SourceGenerators/Shared/ReferencedSpiderlyClassListComparer.cs
@@ -1,0 +1,254 @@
+using Spiderly.SourceGenerators.Models;
+using System.Collections.Generic;
+
+namespace Spiderly.SourceGenerators.Shared
+{
+    internal sealed class ReferencedSpiderlyClassListComparer : IEqualityComparer<List<SpiderlyClass>>
+    {
+        public static readonly ReferencedSpiderlyClassListComparer Instance = new();
+
+        private ReferencedSpiderlyClassListComparer()
+        {
+        }
+
+        public bool Equals(List<SpiderlyClass> x, List<SpiderlyClass> y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null || x.Count != y.Count)
+                return false;
+
+            for (int i = 0; i < x.Count; i++)
+            {
+                if (!ClassEquals(x[i], y[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        public int GetHashCode(List<SpiderlyClass> obj)
+        {
+            if (obj is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                foreach (SpiderlyClass item in obj)
+                    hash = hash * 31 + GetClassHashCode(item);
+
+                return hash;
+            }
+        }
+
+        private static bool ClassEquals(SpiderlyClass x, SpiderlyClass y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            return x.Name == y.Name &&
+                x.Namespace == y.Namespace &&
+                x.BaseType == y.BaseType &&
+                x.IsAbstract == y.IsAbstract &&
+                x.ControllerName == y.ControllerName &&
+                x.IsGenerated == y.IsGenerated &&
+                x.Description == y.Description &&
+                ListEquals(x.Properties, y.Properties, PropertyEquals) &&
+                ListEquals(x.Attributes, y.Attributes, AttributeEquals) &&
+                ListEquals(x.Methods, y.Methods, MethodEquals);
+        }
+
+        private static int GetClassHashCode(SpiderlyClass item)
+        {
+            if (item is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                hash = Add(hash, item.Name);
+                hash = Add(hash, item.Namespace);
+                hash = Add(hash, item.BaseType);
+                hash = Add(hash, item.IsAbstract);
+                hash = Add(hash, item.ControllerName);
+                hash = Add(hash, item.IsGenerated);
+                hash = Add(hash, item.Description);
+                hash = AddList(hash, item.Properties, GetPropertyHashCode);
+                hash = AddList(hash, item.Attributes, GetAttributeHashCode);
+                hash = AddList(hash, item.Methods, GetMethodHashCode);
+                return hash;
+            }
+        }
+
+        private static bool PropertyEquals(SpiderlyProperty x, SpiderlyProperty y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            return EqualityComparer<SpiderlyTypeRef>.Default.Equals(x.Type, y.Type) &&
+                x.Name == y.Name &&
+                x.StringValue == y.StringValue &&
+                x.EntityName == y.EntityName &&
+                x.IsSaveBodyMainDTO == y.IsSaveBodyMainDTO &&
+                x.Description == y.Description &&
+                x.IsEnum == y.IsEnum &&
+                x.IsOneToOnePrincipalInverseNav == y.IsOneToOnePrincipalInverseNav &&
+                ListEquals(x.Attributes, y.Attributes, AttributeEquals);
+        }
+
+        private static int GetPropertyHashCode(SpiderlyProperty item)
+        {
+            if (item is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                hash = Add(hash, item.Type);
+                hash = Add(hash, item.Name);
+                hash = Add(hash, item.StringValue);
+                hash = Add(hash, item.EntityName);
+                hash = Add(hash, item.IsSaveBodyMainDTO);
+                hash = Add(hash, item.Description);
+                hash = Add(hash, item.IsEnum);
+                hash = Add(hash, item.IsOneToOnePrincipalInverseNav);
+                hash = AddList(hash, item.Attributes, GetAttributeHashCode);
+                return hash;
+            }
+        }
+
+        private static bool MethodEquals(SpiderlyMethod x, SpiderlyMethod y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            return x.Name == y.Name &&
+                x.ReturnType == y.ReturnType &&
+                x.Body == y.Body &&
+                ListEquals(x.Parameters, y.Parameters, ParameterEquals) &&
+                ListEquals(x.Attributes, y.Attributes, AttributeEquals);
+        }
+
+        private static int GetMethodHashCode(SpiderlyMethod item)
+        {
+            if (item is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                hash = Add(hash, item.Name);
+                hash = Add(hash, item.ReturnType);
+                hash = Add(hash, item.Body);
+                hash = AddList(hash, item.Parameters, GetParameterHashCode);
+                hash = AddList(hash, item.Attributes, GetAttributeHashCode);
+                return hash;
+            }
+        }
+
+        private static bool ParameterEquals(SpiderParameter x, SpiderParameter y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            return x.Name == y.Name &&
+                EqualityComparer<SpiderlyTypeRef>.Default.Equals(x.Type, y.Type) &&
+                ListEquals(x.Attributes, y.Attributes, AttributeEquals);
+        }
+
+        private static int GetParameterHashCode(SpiderParameter item)
+        {
+            if (item is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                hash = Add(hash, item.Name);
+                hash = Add(hash, item.Type);
+                hash = AddList(hash, item.Attributes, GetAttributeHashCode);
+                return hash;
+            }
+        }
+
+        private static bool AttributeEquals(SpiderlyAttribute x, SpiderlyAttribute y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null)
+                return false;
+
+            return x.Name == y.Name && x.Value == y.Value;
+        }
+
+        private static int GetAttributeHashCode(SpiderlyAttribute item)
+        {
+            if (item is null)
+                return 0;
+
+            unchecked
+            {
+                int hash = 17;
+                hash = Add(hash, item.Name);
+                hash = Add(hash, item.Value);
+                return hash;
+            }
+        }
+
+        private static bool ListEquals<T>(IReadOnlyList<T> x, IReadOnlyList<T> y, System.Func<T, T, bool> equals)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+
+            if (x is null || y is null || x.Count != y.Count)
+                return false;
+
+            for (int i = 0; i < x.Count; i++)
+            {
+                if (!equals(x[i], y[i]))
+                    return false;
+            }
+
+            return true;
+        }
+
+        private static int AddList<T>(int hash, IReadOnlyList<T> items, System.Func<T, int> getHashCode)
+        {
+            unchecked
+            {
+                hash = Add(hash, items?.Count ?? 0);
+
+                if (items is null)
+                    return hash;
+
+                foreach (T item in items)
+                    hash = hash * 31 + getHashCode(item);
+
+                return hash;
+            }
+        }
+
+        private static int Add<T>(int hash, T value)
+        {
+            unchecked
+            {
+                return hash * 31 + EqualityComparer<T>.Default.GetHashCode(value);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add a content comparer for referenced assembly metadata used by source generator incremental pipelines.
- Avoid rewriting generated Angular files when the generated content is unchanged.
- Add regression coverage for equivalent referenced metadata and no-op generated file writes.

## Why

Issue #159 asks why source generators appear to run when an unrelated file such as `Startup.cs` is saved.

This PR does not claim to prevent Roslyn from updating the `CompilationProvider` itself. A normal C# file save can still produce a new compilation. The problem in Spiderly was that the referenced assembly analyzer projected that compilation into a new `List<SpiderlyClass>` each time. Without content equality, equivalent metadata could still invalidate downstream generator steps.

This PR adds content-based equality for that referenced metadata, so equivalent metadata is treated as unchanged by the incremental pipeline.

Separately, Angular generators write files directly. Even when generated content is identical, rewriting the file updates timestamps and makes generator activity visible as unnecessary file churn. This PR skips the write when the file already contains the same content.

So the intent is to reduce no-op generator churn and file rewrites after unrelated saves, not to block Roslyn’s initial compilation update.

## Testing

- `dotnet test Spiderly.SourceGenerators.Tests\Spiderly.SourceGenerators.Tests.csproj --no-restore`
- `dotnet build Spiderly.sln --no-restore`