### PR TITLE
fix: mark agent-reported label as already existing in filiptrivan/spi…

### DIFF
--- a/claude-plugins/skills/report-gap/SKILL.md
+++ b/claude-plugins/skills/report-gap/SKILL.md
@@ -91,11 +91,7 @@ GitHub returns **414 URI Too Long** around **8 KB**, and URL-encoding inflates t
 
 ## One-time setup — the `agent-reported` label
 
-The pre-filled `&labels=agent-reported` only sticks if that label **exists** in the repo — GitHub silently drops unknown labels (you'd still get `enhancement`).
-
-For `filiptrivan/spiderly`, the `agent-reported` label already exists, so no setup is required.
-
-If you're using a fork or another repository that does not already contain this label, create it once:
+The `agent-reported` label already exists in `filiptrivan/spiderly` — no setup required.
 
 
 ```bash

--- a/claude-plugins/skills/report-gap/SKILL.md
+++ b/claude-plugins/skills/report-gap/SKILL.md
@@ -91,7 +91,12 @@ GitHub returns **414 URI Too Long** around **8 KB**, and URL-encoding inflates t
 
 ## One-time setup — the `agent-reported` label
 
-The pre-filled `&labels=agent-reported` only sticks if that label **exists** in the repo — GitHub silently drops unknown labels (you'd still get `enhancement`). Create it once (maintainer, authenticated `gh`):
+The pre-filled `&labels=agent-reported` only sticks if that label **exists** in the repo — GitHub silently drops unknown labels (you'd still get `enhancement`).
+
+For `filiptrivan/spiderly`, the `agent-reported` label already exists, so no setup is required.
+
+If you're using a fork or another repository that does not already contain this label, create it once:
+
 
 ```bash
 gh label create agent-reported \


### PR DESCRIPTION
Summary

The report gap skill made sure that the maintainers would make the agent-reported label, but that label is already available in the filiptrivan/spiderly repo.

Changes

- Added information saying that there is already a label in the main repo.
- Mentioned that no setup needs to be done for filiptrivan/spiderly.
- Made sure to keep the label-making instructions in place for other forks and repos.

Fixes #230