### PR TITLE
fix(agent-evals): make the eval workflow runnable (--db skip) + author add-validator oracle

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -82,7 +82,15 @@ jobs:
         run: |
           npm install -g @anthropic-ai/claude-code
           claude --version
-          claude auth status
+          # `claude auth status` only confirms a token is PRESENT — it returns loggedIn:true even for
+          # an invalid/expired token. A tiny real call validates it against the API; is_error catches a
+          # 401 here (seconds) instead of after the ~8-min fixture build.
+          probe=$(claude -p "Reply with exactly: OK" --max-turns 1 --output-format json || true)
+          echo "$probe"
+          if echo "$probe" | grep -q '"is_error":true'; then
+            echo "::error::Claude auth probe failed — invalid/expired CLAUDE_CODE_OAUTH_TOKEN. Regenerate with 'claude setup-token' and update the repo secret."
+            exit 1
+          fi
 
       # --- Build the `spiderly-app` fixture in CI (the pre-task state) ---
       # Mirrors ci.yml's integration-test scaffold: build+pack packages, publish the Angular lib to a

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -127,7 +127,10 @@ jobs:
         run: |
           export PATH="$HOME/.dotnet/tools:$PATH"
           cd ..
-          spiderly init --name "${{ env.TEST_APP_NAME }}" --db postgresql
+          # --db skip: the eval only runs `dotnet build` (no DB / migrations / running app), so we
+          # skip DB provisioning entirely. That's why this workflow needs no Postgres service —
+          # unlike ci.yml's integration-test, which boots the app and so sets up Postgres first.
+          spiderly init --name "${{ env.TEST_APP_NAME }}" --db skip
 
       # Apply the eval overlay: the add-validator PRE-task Product (Name present, NO validation).
       # We deliberately do NOT run tests/e2e-fixtures/setup.sh — that overlay's Product.Name already

--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -72,6 +72,18 @@ jobs:
       - name: Harness self-test
         run: cd tools && npm run test:evals
 
+      # Fail fast on a bad/expired Claude token BEFORE the ~8-min fixture build. Only for `claude`
+      # runs. Installs the CLI here (reused by "Run evals"); `claude auth status` exits 1 if not
+      # authenticated, failing the job early with a clear signal instead of a silent 0-token no-op.
+      - name: Verify Claude auth (fail fast)
+        if: contains(inputs.agents, 'claude')
+        env:
+          CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+        run: |
+          npm install -g @anthropic-ai/claude-code
+          claude --version
+          claude auth status
+
       # --- Build the `spiderly-app` fixture in CI (the pre-task state) ---
       # Mirrors ci.yml's integration-test scaffold: build+pack packages, publish the Angular lib to a
       # local Verdaccio, install the CLI, then `spiderly init`. Only the BACKEND is kept as the
@@ -156,11 +168,7 @@ jobs:
           mkdir -p "$DEST"
           rsync -a --exclude bin --exclude obj "${{ env.APP_FOLDER }}/Backend" "$DEST/"
 
-      # --- Run the agents ---
-      - name: Install Claude Code CLI
-        if: contains(inputs.agents, 'claude')
-        run: npm install -g @anthropic-ai/claude-code
-
+      # --- Run the agents (Claude CLI already installed + auth-verified above) ---
       - name: Run evals
         env:
           # Claude Pro/Max subscription token (headless `claude` reads this directly). Swap for

--- a/tools/agent-evals/agents/claude.mjs
+++ b/tools/agent-evals/agents/claude.mjs
@@ -1,18 +1,22 @@
 import { run } from '../lib/exec.mjs';
 
 // Real Claude Code headless run. Edits the workspace in place over multiple turns.
-// Requires `claude` on PATH and credentials (logged-in CLI or ANTHROPIC_API_KEY) in env.
+// Auth (any one): a logged-in CLI, ANTHROPIC_API_KEY, or a Pro/Max CLAUDE_CODE_OAUTH_TOKEN in env.
 // NOTE: Date.now() is fine here — this is an ordinary Node CLI, not a Workflow() sandbox.
 export default {
   name: 'claude',
   async run({ workspaceDir, prompt, maxTurns }) {
     const start = Date.now();
+    // shell:false on POSIX so the multi-word `prompt` is passed as a SINGLE argv entry — under
+    // shell:true the shell re-splits it into garbage args and `claude` exits immediately (0 turns).
+    // Windows still needs shell:true to launch the `claude.cmd` shim (Node won't spawn .cmd without
+    // a shell), where Node applies its own arg quoting.
     const res = run('claude', [
       '-p', prompt,
       '--output-format', 'json',
       '--max-turns', String(maxTurns ?? 20),
       '--permission-mode', 'bypassPermissions',
-    ], { cwd: workspaceDir, shell: true, timeoutMs: 20 * 60 * 1000 });
+    ], { cwd: workspaceDir, shell: process.platform === 'win32', timeoutMs: 20 * 60 * 1000 });
     const wallMs = Date.now() - start;
 
     let meta = { tokens: 0, costUsd: 0, turns: 0 };
@@ -23,8 +27,15 @@ export default {
         costUsd: j.total_cost_usd ?? 0,
         turns: j.num_turns ?? 0,
       };
-    } catch { /* non-JSON output (e.g. crash) — keep defaults, transcript still captured */ }
+    } catch { /* non-JSON stdout (e.g. startup crash) — keep defaults; the error is on stderr, below */ }
 
-    return { transcript: res.stdout, ...meta, wallMs, cleanExit: res.code === 0 };
+    // claude prints its run JSON to stdout but startup errors (bad auth/flags) to stderr — surface
+    // those so a failed run is diagnosable instead of a silent 0-turns no-op.
+    if (res.code !== 0 && res.stderr.trim()) {
+      console.error(`[claude] exit ${res.code}: ${res.stderr.trim().slice(-1500)}`);
+    }
+    const transcript = res.stdout + (res.stderr.trim() ? `\n[stderr]\n${res.stderr.trim()}` : '');
+
+    return { transcript, ...meta, wallMs, cleanExit: res.code === 0 };
   },
 };

--- a/tools/agent-evals/agents/claude.mjs
+++ b/tools/agent-evals/agents/claude.mjs
@@ -29,10 +29,11 @@ export default {
       };
     } catch { /* non-JSON stdout (e.g. startup crash) — keep defaults; the error is on stderr, below */ }
 
-    // claude prints its run JSON to stdout but startup errors (bad auth/flags) to stderr — surface
-    // those so a failed run is diagnosable instead of a silent 0-turns no-op.
-    if (res.code !== 0 && res.stderr.trim()) {
-      console.error(`[claude] exit ${res.code}: ${res.stderr.trim().slice(-1500)}`);
+    // On failure, surface BOTH streams: claude reports run/usage errors in the stdout result JSON
+    // (e.g. auth/quota) and startup errors on stderr. matrix.json keeps only agentMeta, so this log
+    // is the only place the cause is visible — without it a failure looks like a silent 0-turn no-op.
+    if (res.code !== 0) {
+      console.error(`[claude] exit ${res.code}\n[stdout] ${res.stdout.trim().slice(-1500)}\n[stderr] ${res.stderr.trim().slice(-800)}`);
     }
     const transcript = res.stdout + (res.stderr.trim() ? `\n[stderr]\n${res.stderr.trim()}` : '');
 

--- a/tools/agent-evals/oracle/add-validator/Backend/TestApp.Business/Entities/Product.cs
+++ b/tools/agent-evals/oracle/add-validator/Backend/TestApp.Business/Entities/Product.cs
@@ -1,0 +1,21 @@
+using System.ComponentModel.DataAnnotations;
+using Spiderly.Shared.Attributes.Entity;
+using Spiderly.Shared.Attributes.Entity.UI;
+using Spiderly.Shared.BaseEntities;
+
+namespace TestApp.Business.Entities
+{
+    // Known-good solution for the `add-validator` task: Product.Name is now required + max 100 via
+    // DataAnnotations (Spiderly generates the FluentValidation + Angular validators from these).
+    // Overlaid verbatim onto the staged fixture (oracle.mjs copies, no sed), so the namespace is the
+    // concrete TEST_APP_NAME — not the __APP_NAME__ placeholder the pre-task fixture uses.
+    [SpiderlyEntity]
+    [DoNotAuthorize]
+    public class Product : BusinessObject<int>
+    {
+        [DisplayName]
+        [Required]
+        [MaxLength(100)]
+        public string Name { get; set; }
+    }
+}

--- a/tools/agent-evals/report.mjs
+++ b/tools/agent-evals/report.mjs
@@ -4,10 +4,19 @@ export function renderReport(matrix) {
   const groups = new Map();
   for (const r of matrix.rows) {
     const k = `${r.agent}__${r.taskId}`;
-    if (!groups.has(k)) groups.set(k, { agent: r.agent, taskId: r.taskId, pass: 0, total: 0, infra: 0 });
+    if (!groups.has(k)) {
+      groups.set(k, { agent: r.agent, taskId: r.taskId, pass: 0, total: 0, infra: 0, costSum: 0, turnsSum: 0, ran: 0 });
+    }
     const g = groups.get(k);
     if (r.pass === null) g.infra++;
     else { g.total++; if (r.pass) g.pass++; }
+    // Efficiency metrics average over every rep where the agent actually ran (agentMeta present) —
+    // including an infra row that failed in verify, since the agent's cost/turns were still incurred.
+    if (r.agentMeta) {
+      g.costSum += r.agentMeta.costUsd ?? 0;
+      g.turnsSum += r.agentMeta.turns ?? 0;
+      g.ran++;
+    }
   }
 
   const lines = [
@@ -15,13 +24,17 @@ export function renderReport(matrix) {
     '',
     `Track: ${matrix.meta.track} · reps: ${matrix.meta.reps}`,
     '',
-    '| Agent | Task | Pass rate | Infra errors |',
-    '|---|---|---|---|',
+    '| Agent | Task | Pass rate | Mean cost | Mean turns | Infra errors |',
+    '|---|---|---|---|---|---|',
   ];
   for (const g of [...groups.values()].sort((a, b) => a.agent.localeCompare(b.agent) || a.taskId.localeCompare(b.taskId))) {
     // total===0 means no scored reps (all infra errors) — render '—' so it reads distinctly from a real 0/N.
     const rate = g.total === 0 ? '—' : `${g.pass}/${g.total}`;
-    lines.push(`| ${g.agent} | ${g.taskId} | ${rate} | ${g.infra} |`);
+    // Efficiency signal: when pass rate is pinned (all 0/N or N/N), a guidance change still shows up
+    // here as fewer turns / lower cost. '—' when the agent never ran (so means aren't faked as 0).
+    const meanCost = g.ran === 0 ? '—' : `$${(g.costSum / g.ran).toFixed(4)}`;
+    const meanTurns = g.ran === 0 ? '—' : (g.turnsSum / g.ran).toFixed(1);
+    lines.push(`| ${g.agent} | ${g.taskId} | ${rate} | ${meanCost} | ${meanTurns} | ${g.infra} |`);
   }
 
   const fails = matrix.rows.filter((r) => r.pass === false);

--- a/tools/agent-evals/report.test.mjs
+++ b/tools/agent-evals/report.test.mjs
@@ -5,8 +5,8 @@ import { renderReport } from './report.mjs';
 const matrix = {
   meta: { runId: 'r1', track: 'agnostic', reps: 2 },
   rows: [
-    { agent: 'claude', taskId: 'add-validator', rep: 0, pass: true, checks: [{ name: 'compiles', pass: true }] },
-    { agent: 'claude', taskId: 'add-validator', rep: 1, pass: false, checks: [{ name: 'compiles', pass: false }] },
+    { agent: 'claude', taskId: 'add-validator', rep: 0, pass: true, checks: [{ name: 'compiles', pass: true }], agentMeta: { costUsd: 0.20, turns: 4, tokens: 100, wallMs: 1, cleanExit: true } },
+    { agent: 'claude', taskId: 'add-validator', rep: 1, pass: false, checks: [{ name: 'compiles', pass: false }], agentMeta: { costUsd: 0.10, turns: 2, tokens: 50, wallMs: 1, cleanExit: true } },
     { agent: 'claude', taskId: 'add-validator', rep: 0, pass: null, error: 'boom', checks: [] },
   ],
 };
@@ -16,4 +16,12 @@ test('renderReport shows pass rate, infra-error count, and a failure digest', ()
   assert.match(md, /1\/2/, 'pass rate excludes the infra-error row');
   assert.match(md, /Failure digest/);
   assert.match(md, /compiles/, 'failed check named in the digest');
+});
+
+test('renderReport averages cost and turns over the reps that executed', () => {
+  const md = renderReport(matrix);
+  assert.match(md, /Mean cost/);
+  assert.match(md, /Mean turns/);
+  assert.match(md, /\$0\.1500/, 'mean cost = (0.20 + 0.10) / 2 over the two rows with agentMeta');
+  assert.match(md, /3\.0/, 'mean turns = (4 + 2) / 2');
 });


### PR DESCRIPTION
Makes `agent-evals.yml` actually run end-to-end and completes the oracle/no-op self-test on the first real task.

## What & why
- **`spiderly init --db skip`** — the eval is `dotnet build`-only (no DB, migrations, or running app), but `--db postgresql` tried to provision Postgres and failed (this workflow intentionally runs no Postgres service). `--db skip` is a first-class CLI mode (`InitCommand.cs`) that scaffolds + builds without a database. Fixes the fixture-build step.
- **Authored `oracle/add-validator/.../Product.cs`** — the known-good solution (`[Required]` + `[MaxLength(100)]` on `Product.Name`), so the oracle scores 1/1 on the real task.

## Validated out-of-band (free oracle/noop runs on this branch)
- oracle: add-validator **1/1**, trivial-marker 1/1
- noop: add-validator 0/1 (fails `name-required`, `name-max-100`), trivial-marker 0/1

→ the oracle-100% / no-op-0% discrimination gate passes on the real task; the CI fixture build + verifier work end-to-end.

> Note: `main`'s copy of the workflow still has the broken `--db postgresql`; this needs to ride to `main` (release flow) so the registered/dispatchable workflow is the working version.

🤖 Generated with [Claude Code](https://claude.com/claude-code)