### PR TITLE
feat(security): ambient principal keystone + job-principal flow (auth Phase 1)

### DIFF
--- a/Spiderly.Security/PrincipalKinds.cs
+++ b/Spiderly.Security/PrincipalKinds.cs
@@ -1,3 +1,5 @@
+using Spiderly.Shared.Authorization;
+
 namespace Spiderly.Security
 {
     /// <summary>

--- a/Spiderly.Security/Services/AuthenticationService.cs
+++ b/Spiderly.Security/Services/AuthenticationService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Options;
 using Spiderly.Security.DTO;
 using Spiderly.Security.Interfaces;
 using Spiderly.Shared;
+using Spiderly.Shared.Authorization;
 using Spiderly.Shared.Extensions;
 using Spiderly.Shared.Helpers;
 using Spiderly.Shared.Interfaces;
@@ -21,6 +22,7 @@ namespace Spiderly.Security.Services
     public class AuthenticationService : ServiceBase
     {
         private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly ISpiderlyPrincipalAccessor _principalAccessor;
         private readonly IApplicationDbContext _context;
         private readonly AuthPolicyOptions _authPolicySettings;
         private readonly TokenKeyOptions _tokenKeySettings;
@@ -28,6 +30,7 @@ namespace Spiderly.Security.Services
 
         public AuthenticationService(
             IHttpContextAccessor httpContextAccessor,
+            ISpiderlyPrincipalAccessor principalAccessor,
             IApplicationDbContext context,
             IStringLocalizer localizer,
             IOptions<AuthPolicyOptions> authPolicyOptions,
@@ -37,31 +40,38 @@ namespace Spiderly.Security.Services
             : base(context, localizer)
         {
             _httpContextAccessor = httpContextAccessor;
+            _principalAccessor = principalAccessor;
             _context = context;
             _authPolicySettings = authPolicyOptions.Value;
             _tokenKeySettings = tokenKeyOptions.Value;
             _cookieManager = cookieManager;
         }
 
+        /// <summary>
+        /// The current principal's user id. Throws <see cref="System.InvalidOperationException"/> when there is
+        /// no authenticated principal in the current execution context — call <see cref="GetCurrentUserIdOrDefault"/>
+        /// on paths that may run anonymously or outside an HTTP request (e.g. background jobs).
+        /// </summary>
         public virtual long GetCurrentUserId()
         {
-            return Helper.GetCurrentUserId(_httpContextAccessor.HttpContext);
+            return _principalAccessor.Current.UserId
+                ?? throw new System.InvalidOperationException("There is no authenticated principal in the current execution context.");
         }
 
+        /// <summary>The current principal's user id, or <c>null</c> when the context is anonymous (no authenticated caller).</summary>
         public virtual long? GetCurrentUserIdOrDefault()
         {
-            return Helper.GetCurrentUserIdOrDefault(_httpContextAccessor.HttpContext);
+            return _principalAccessor.Current.UserId;
         }
 
         /// <summary>
-        /// The kind of the current principal, read from the <c>principal_kind</c> claim, or <c>null</c> when
+        /// The kind of the current principal, from the <c>principal_kind</c> claim, or <c>null</c> when
         /// the claim is absent (the single-principal case). The authorization core's registry resolves a
         /// <c>null</c> kind to the single registered kind, so single-principal applications carry no claim ceremony.
         /// </summary>
         public virtual string GetCurrentPrincipalKind()
         {
-            return _httpContextAccessor.HttpContext?.User?.Claims
-                .FirstOrDefault(c => c.Type == PrincipalClaims.PrincipalKind)?.Value;
+            return _principalAccessor.Current.Kind;
         }
 
         public virtual async Task<string> GetCurrentUserEmail<TUser>() where TUser : class, IUser, new()

--- a/Spiderly.Security/Services/JwtAuthManagerService.cs
+++ b/Spiderly.Security/Services/JwtAuthManagerService.cs
@@ -4,6 +4,7 @@ using Microsoft.IdentityModel.Tokens;
 using Spiderly.Security.DTO;
 using Spiderly.Security.Interfaces;
 using Spiderly.Shared;
+using Spiderly.Shared.Authorization;
 using Spiderly.Shared.Exceptions;
 using Spiderly.Shared.Interfaces;
 using Microsoft.IdentityModel.JsonWebTokens;

--- a/Spiderly.Shared.Tests/SpiderlyPrincipalAccessorTests.cs
+++ b/Spiderly.Shared.Tests/SpiderlyPrincipalAccessorTests.cs
@@ -1,0 +1,147 @@
+using System;
+using System.Collections.Generic;
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Spiderly.Shared.Authorization;
+using Xunit;
+
+namespace Spiderly.Shared.Tests
+{
+    // Keystone of the transport-agnostic principal model: identity is read from this accessor (AsyncLocal,
+    // with an HTTP fallback) instead of HttpContext directly, so the same code resolves identity under HTTP,
+    // background jobs, and tests. These tests pin: the anonymous default (no NRE when there's no HttpContext —
+    // closes the Hangfire landmine), explicit push/restore precedence, nesting, and the HTTP claims fallback.
+    public class SpiderlyPrincipalAccessorTests
+    {
+        // No HttpContext (e.g. a background job) and nothing pushed → Anonymous, never a throw. This is the
+        // landmine fix: the old AuthenticationService read HttpContext directly and NRE'd in non-HTTP contexts.
+        [Fact]
+        public void Current_is_Anonymous_when_no_http_context_and_nothing_pushed()
+        {
+            SpiderlyPrincipalAccessor accessor = new(new HttpContextAccessor());
+
+            SpiderlyPrincipal current = accessor.Current;
+
+            Assert.NotNull(current);
+            Assert.Null(current.UserId);
+            Assert.False(current.IsAuthenticated);
+            Assert.False(current.IsSystem);
+        }
+
+        [Fact]
+        public void Push_makes_principal_current_and_restores_previous_on_dispose()
+        {
+            SpiderlyPrincipalAccessor accessor = new(new HttpContextAccessor());
+
+            using (accessor.Push(SpiderlyPrincipal.ForUser(42, "User")))
+            {
+                Assert.Equal(42, accessor.Current.UserId);
+                Assert.Equal("User", accessor.Current.Kind);
+                Assert.True(accessor.Current.IsAuthenticated);
+            }
+
+            // Scope disposed → back to the empty baseline.
+            Assert.Null(accessor.Current.UserId);
+            Assert.False(accessor.Current.IsAuthenticated);
+        }
+
+        [Fact]
+        public void Push_nests_and_each_dispose_restores_the_enclosing_principal()
+        {
+            SpiderlyPrincipalAccessor accessor = new(new HttpContextAccessor());
+
+            using (accessor.Push(SpiderlyPrincipal.ForUser(1)))
+            {
+                Assert.Equal(1, accessor.Current.UserId);
+
+                using (accessor.Push(SpiderlyPrincipal.ForUser(2)))
+                {
+                    Assert.Equal(2, accessor.Current.UserId);
+                }
+
+                Assert.Equal(1, accessor.Current.UserId);
+            }
+
+            Assert.Null(accessor.Current.UserId);
+        }
+
+        [Fact]
+        public void System_principal_has_no_user_but_flags_IsSystem()
+        {
+            SpiderlyPrincipalAccessor accessor = new(new HttpContextAccessor());
+
+            using (accessor.Push(SpiderlyPrincipal.System))
+            {
+                Assert.Null(accessor.Current.UserId);
+                Assert.False(accessor.Current.IsAuthenticated);
+                Assert.True(accessor.Current.IsSystem);
+            }
+        }
+
+        // The HTTP adapter: when nothing is pushed, identity is resolved from the authenticated request's claims.
+        [Fact]
+        public void Current_falls_back_to_authenticated_http_context_claims()
+        {
+            HttpContextAccessor httpContextAccessor = new()
+            {
+                HttpContext = BuildAuthenticatedContext(userId: 7, kind: "User"),
+            };
+            SpiderlyPrincipalAccessor accessor = new(httpContextAccessor);
+
+            Assert.Equal(7, accessor.Current.UserId);
+            Assert.Equal("User", accessor.Current.Kind);
+            Assert.True(accessor.Current.IsAuthenticated);
+        }
+
+        // An explicitly pushed principal wins over the ambient HTTP context (e.g. impersonation / a job filter).
+        [Fact]
+        public void Pushed_principal_takes_precedence_over_http_context()
+        {
+            HttpContextAccessor httpContextAccessor = new()
+            {
+                HttpContext = BuildAuthenticatedContext(userId: 7, kind: "User"),
+            };
+            SpiderlyPrincipalAccessor accessor = new(httpContextAccessor);
+
+            using (accessor.Push(SpiderlyPrincipal.System))
+            {
+                Assert.True(accessor.Current.IsSystem);
+                Assert.Null(accessor.Current.UserId);
+            }
+
+            // After dispose, the HTTP fallback applies again.
+            Assert.Equal(7, accessor.Current.UserId);
+        }
+
+        [Fact]
+        public void Current_is_Anonymous_when_http_context_is_unauthenticated()
+        {
+            HttpContextAccessor httpContextAccessor = new() { HttpContext = new DefaultHttpContext() };
+            SpiderlyPrincipalAccessor accessor = new(httpContextAccessor);
+
+            Assert.Null(accessor.Current.UserId);
+            Assert.False(accessor.Current.IsAuthenticated);
+        }
+
+        [Fact]
+        public void Push_null_throws()
+        {
+            SpiderlyPrincipalAccessor accessor = new(new HttpContextAccessor());
+
+            Assert.Throws<ArgumentNullException>(() => accessor.Push(null));
+        }
+
+        private static DefaultHttpContext BuildAuthenticatedContext(long userId, string kind)
+        {
+            List<Claim> claims = new()
+            {
+                new Claim(ClaimTypes.NameIdentifier, userId.ToString()),
+                new Claim(PrincipalClaims.PrincipalKind, kind),
+            };
+
+            // A non-null authentication type makes ClaimsIdentity.IsAuthenticated return true.
+            ClaimsIdentity identity = new(claims, authenticationType: "Test");
+            return new DefaultHttpContext { User = new ClaimsPrincipal(identity) };
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/HangfirePrincipalFilter.cs
+++ b/Spiderly.Shared/Authorization/HangfirePrincipalFilter.cs
@@ -1,0 +1,78 @@
+using System;
+using Hangfire.Client;
+using Hangfire.Server;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Hangfire client + server filter that carries the current principal into background work, so identity
+    /// reads and audit inside a job see the right actor instead of an empty context.
+    /// <para>
+    /// <b>Capture (client side):</b> when a job is enqueued while an authenticated principal is current (e.g. an
+    /// admin request that schedules work), the principal's id and kind are stamped onto the job.
+    /// <b>Restore (server side):</b> for the duration of job execution the captured principal is pushed onto
+    /// <see cref="ISpiderlyPrincipalAccessor"/>; jobs with no captured actor (recurring / scheduler-enqueued)
+    /// run as <see cref="SpiderlyPrincipal.System"/>.
+    /// </para>
+    /// <para>
+    /// Only the principal's id and kind travel with the job — never tokens or credentials. Background work is
+    /// trusted (it is not re-authorized against the captured principal's live permissions); <b>attribution</b>,
+    /// not authorization, is what flows in. Registered via <c>app.SpiderlyUseHangfirePrincipalFilter()</c>.
+    /// </para>
+    /// </summary>
+    public sealed class HangfirePrincipalFilter : IClientFilter, IServerFilter
+    {
+        private const string UserIdParameter = "SpiderlyPrincipalUserId";
+        private const string KindParameter = "SpiderlyPrincipalKind";
+        private const string ScopeItemKey = "SpiderlyPrincipalScope";
+
+        private readonly ISpiderlyPrincipalAccessor _principalAccessor;
+
+        /// <summary>Creates the filter over the singleton principal accessor.</summary>
+        /// <param name="principalAccessor">The accessor whose principal is captured at enqueue and pushed during execution.</param>
+        public HangfirePrincipalFilter(ISpiderlyPrincipalAccessor principalAccessor)
+        {
+            _principalAccessor = principalAccessor;
+        }
+
+        /// <summary>Captures the enqueuing principal (id and kind) onto the job, when one is authenticated.</summary>
+        /// <param name="context">The Hangfire job-creation context.</param>
+        public void OnCreating(CreatingContext context)
+        {
+            SpiderlyPrincipal current = _principalAccessor.Current;
+            if (current.IsAuthenticated == false || current.UserId.HasValue == false)
+                return;
+
+            context.SetJobParameter(UserIdParameter, current.UserId.Value);
+            if (string.IsNullOrEmpty(current.Kind) == false)
+                context.SetJobParameter(KindParameter, current.Kind);
+        }
+
+        /// <summary>No-op; capture happens in <see cref="OnCreating"/>.</summary>
+        /// <param name="context">The Hangfire job-created context.</param>
+        public void OnCreated(CreatedContext context) { }
+
+        /// <summary>
+        /// Pushes the captured principal — or <see cref="SpiderlyPrincipal.System"/> when none was captured —
+        /// for the duration of the job, storing the restore scope in <see cref="PerformContext.Items"/>.
+        /// </summary>
+        /// <param name="context">The Hangfire job-performing context.</param>
+        public void OnPerforming(PerformingContext context)
+        {
+            long? userId = context.GetJobParameter<long?>(UserIdParameter);
+            SpiderlyPrincipal principal = userId.HasValue
+                ? SpiderlyPrincipal.ForUser(userId.Value, context.GetJobParameter<string>(KindParameter))
+                : SpiderlyPrincipal.System;
+
+            context.Items[ScopeItemKey] = _principalAccessor.Push(principal);
+        }
+
+        /// <summary>Restores the previous principal by disposing the scope pushed in <see cref="OnPerforming"/>.</summary>
+        /// <param name="context">The Hangfire job-performed context.</param>
+        public void OnPerformed(PerformedContext context)
+        {
+            if (context.Items.TryGetValue(ScopeItemKey, out object scope) && scope is IDisposable disposable)
+                disposable.Dispose();
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/ISpiderlyPrincipalAccessor.cs
+++ b/Spiderly.Shared/Authorization/ISpiderlyPrincipalAccessor.cs
@@ -1,0 +1,29 @@
+using System;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Transport-agnostic access to the principal executing the current logical operation. Replaces direct
+    /// <c>HttpContext</c> reads so the same business code resolves identity identically under an HTTP request,
+    /// a background job, or a unit test. The default implementation
+    /// (<see cref="SpiderlyPrincipalAccessor"/>) is backed by an <see cref="System.Threading.AsyncLocal{T}"/>
+    /// and falls back to the ambient HTTP request when nothing has been pushed explicitly.
+    /// </summary>
+    public interface ISpiderlyPrincipalAccessor
+    {
+        /// <summary>
+        /// The current principal. Never <c>null</c>: returns <see cref="SpiderlyPrincipal.Anonymous"/> when no
+        /// principal has been established (an unauthenticated request, or a job with no actor pushed).
+        /// </summary>
+        SpiderlyPrincipal Current { get; }
+
+        /// <summary>
+        /// Establishes <paramref name="principal"/> as the current principal for the calling async flow,
+        /// returning a scope that restores the previous principal when disposed. Used by transport adapters
+        /// (authentication middleware, background-job filters) and tests; safe to nest.
+        /// </summary>
+        /// <param name="principal">The principal to make current. Must not be <c>null</c>.</param>
+        /// <returns>A disposable scope that restores the previous principal on dispose.</returns>
+        IDisposable Push(SpiderlyPrincipal principal);
+    }
+}

--- a/Spiderly.Shared/Authorization/PrincipalClaims.cs
+++ b/Spiderly.Shared/Authorization/PrincipalClaims.cs
@@ -1,4 +1,4 @@
-namespace Spiderly.Security
+namespace Spiderly.Shared.Authorization
 {
     /// <summary>
     /// Custom claim types Spiderly stamps onto an authenticated principal in addition to the standard

--- a/Spiderly.Shared/Authorization/SpiderlyPrincipal.cs
+++ b/Spiderly.Shared/Authorization/SpiderlyPrincipal.cs
@@ -1,0 +1,59 @@
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Immutable snapshot of the principal executing the current logical operation, independent of transport
+    /// (HTTP request, background job, test). Carries <b>identity only</b> — never permissions; authorization
+    /// decisions are resolved separately through <see cref="IPrincipalRegistry"/> when an operation needs them.
+    /// Obtained from <see cref="ISpiderlyPrincipalAccessor"/>.
+    /// </summary>
+    public sealed class SpiderlyPrincipal
+    {
+        /// <summary>The principal's user id (subject), or <c>null</c> for an anonymous or system context.</summary>
+        public long? UserId { get; }
+
+        /// <summary>
+        /// The principal kind (e.g. <c>User</c>, <c>ServiceAccount</c>), or <c>null</c> for the single-principal
+        /// default. Mirrors the <see cref="PrincipalClaims.PrincipalKind"/> claim; the authorization core's
+        /// registry resolves a <c>null</c> kind to the single registered kind.
+        /// </summary>
+        public string Kind { get; }
+
+        /// <summary>True when this principal represents an authenticated end user (has a <see cref="UserId"/>).</summary>
+        public bool IsAuthenticated { get; }
+
+        /// <summary>
+        /// True when this principal represents trusted background/system execution with no end user
+        /// (e.g. a recurring Hangfire job). Authorization layers may treat this as a bypass.
+        /// </summary>
+        public bool IsSystem { get; }
+
+        private SpiderlyPrincipal(long? userId, string kind, bool isAuthenticated, bool isSystem)
+        {
+            UserId = userId;
+            Kind = kind;
+            IsAuthenticated = isAuthenticated;
+            IsSystem = isSystem;
+        }
+
+        /// <summary>
+        /// The empty principal for a context with no established caller (an unauthenticated request, or a
+        /// background job before any actor is pushed). <see cref="IsAuthenticated"/> and <see cref="IsSystem"/>
+        /// are both <c>false</c> and <see cref="UserId"/> is <c>null</c>.
+        /// </summary>
+        public static readonly SpiderlyPrincipal Anonymous = new(userId: null, kind: null, isAuthenticated: false, isSystem: false);
+
+        /// <summary>
+        /// Trusted background/system execution with no end user (e.g. a recurring Hangfire job). Use this as the
+        /// pushed principal for system-initiated work so audit attributes to "system" and authorization can
+        /// treat <see cref="IsSystem"/> as a bypass.
+        /// </summary>
+        public static readonly SpiderlyPrincipal System = new(userId: null, kind: null, isAuthenticated: false, isSystem: true);
+
+        /// <summary>Creates an authenticated end-user principal.</summary>
+        /// <param name="userId">The authenticated user's id (subject).</param>
+        /// <param name="kind">The principal kind, or <c>null</c> for the single-principal default.</param>
+        /// <returns>A principal with <see cref="IsAuthenticated"/> set to <c>true</c>.</returns>
+        public static SpiderlyPrincipal ForUser(long userId, string kind = null) =>
+            new(userId, kind, isAuthenticated: true, isSystem: false);
+    }
+}

--- a/Spiderly.Shared/Authorization/SpiderlyPrincipalAccessor.cs
+++ b/Spiderly.Shared/Authorization/SpiderlyPrincipalAccessor.cs
@@ -1,0 +1,88 @@
+using System;
+using System.Linq;
+using System.Security.Claims;
+using System.Threading;
+using Microsoft.AspNetCore.Http;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Default <see cref="ISpiderlyPrincipalAccessor"/>: an <see cref="AsyncLocal{T}"/>-backed accessor that
+    /// prefers an explicitly pushed principal (set by an authentication middleware, a background-job filter, or
+    /// a test) and otherwise falls back to the ambient HTTP request's claims. Confines all <c>HttpContext</c>
+    /// knowledge to this adapter, so the rest of the framework reads identity transport-agnostically.
+    /// </summary>
+    /// <remarks>
+    /// Registered as a <b>singleton</b> — the per-flow value lives in the static <see cref="AsyncLocal{T}"/>,
+    /// not in the instance, mirroring ASP.NET Core's <see cref="IHttpContextAccessor"/>.
+    /// </remarks>
+    public sealed class SpiderlyPrincipalAccessor : ISpiderlyPrincipalAccessor
+    {
+        private static readonly AsyncLocal<SpiderlyPrincipal> _current = new();
+        private readonly IHttpContextAccessor _httpContextAccessor;
+
+        /// <summary>Creates the accessor over the ambient <see cref="IHttpContextAccessor"/> used for the HTTP fallback.</summary>
+        /// <param name="httpContextAccessor">
+        /// Accessor for the current HTTP context; its <c>HttpContext</c> is <c>null</c> outside a request
+        /// (e.g. inside a background job), in which case <see cref="Current"/> reports
+        /// <see cref="SpiderlyPrincipal.Anonymous"/> unless a principal has been pushed.
+        /// </param>
+        public SpiderlyPrincipalAccessor(IHttpContextAccessor httpContextAccessor)
+        {
+            _httpContextAccessor = httpContextAccessor;
+        }
+
+        /// <inheritdoc/>
+        public SpiderlyPrincipal Current => _current.Value ?? ResolveFromHttpContext() ?? SpiderlyPrincipal.Anonymous;
+
+        /// <inheritdoc/>
+        public IDisposable Push(SpiderlyPrincipal principal)
+        {
+            if (principal == null)
+                throw new ArgumentNullException(nameof(principal));
+
+            SpiderlyPrincipal previous = _current.Value;
+            _current.Value = principal;
+            return new PrincipalScope(previous);
+        }
+
+        /// <summary>
+        /// Builds a principal from the current HTTP request's authenticated claims, or <c>null</c> when there is
+        /// no HTTP context (e.g. a background job) or the request is unauthenticated / carries no usable subject.
+        /// </summary>
+        private SpiderlyPrincipal ResolveFromHttpContext()
+        {
+            HttpContext httpContext = _httpContextAccessor?.HttpContext;
+            if (httpContext?.User?.Identity?.IsAuthenticated != true)
+                return null;
+
+            string subject = httpContext.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value;
+            if (long.TryParse(subject, out long userId) == false)
+                return null;
+
+            string kind = httpContext.User.Claims.FirstOrDefault(x => x.Type == PrincipalClaims.PrincipalKind)?.Value;
+            return SpiderlyPrincipal.ForUser(userId, kind);
+        }
+
+        /// <summary>Restores the previous principal on dispose; idempotent.</summary>
+        private sealed class PrincipalScope : IDisposable
+        {
+            private readonly SpiderlyPrincipal _previous;
+            private bool _disposed;
+
+            public PrincipalScope(SpiderlyPrincipal previous)
+            {
+                _previous = previous;
+            }
+
+            public void Dispose()
+            {
+                if (_disposed)
+                    return;
+
+                _disposed = true;
+                _current.Value = _previous;
+            }
+        }
+    }
+}

--- a/Spiderly.Shared/Extensions/StartupExtensions.cs
+++ b/Spiderly.Shared/Extensions/StartupExtensions.cs
@@ -122,6 +122,12 @@ namespace Spiderly.Shared.Extensions
             // override it with a custom implementation.
             services.TryAddSingleton<IPrincipalRegistry, PrincipalRegistry>();
 
+            // Transport-agnostic current-principal accessor. Singleton: the per-flow value lives in an
+            // AsyncLocal, not the instance (mirrors IHttpContextAccessor). Falls back to the ambient HTTP
+            // request when nothing is pushed, so HTTP apps work without extra wiring; background-job filters
+            // and tests push an explicit principal. TryAdd lets a consumer override with a custom accessor.
+            services.TryAddSingleton<ISpiderlyPrincipalAccessor, SpiderlyPrincipalAccessor>();
+
             // Singleton so the dedupe cache is shared across all notification dispatches.
             services.AddSingleton<NotificationRateLimiter>();
 

--- a/Spiderly.Shared/Extensions/StartupExtensions.cs
+++ b/Spiderly.Shared/Extensions/StartupExtensions.cs
@@ -565,6 +565,26 @@ namespace Spiderly.Shared.Extensions
                 services.GetRequiredService<ILoggerFactory>().CreateLogger<HangfireFailedJobNotificationFilter>()));
         }
 
+        /// <summary>
+        /// Registers the global Hangfire filter that carries the current principal into background jobs: it
+        /// captures the enqueuing principal (when one is authenticated) and restores it for the duration of job
+        /// execution via <see cref="ISpiderlyPrincipalAccessor"/>, defaulting to
+        /// <see cref="Authorization.SpiderlyPrincipal.System"/> for recurring / scheduler-enqueued jobs. Call in
+        /// the Configure phase (after the DI container is built). Only the principal id and kind travel with the
+        /// job — never tokens; background work carries attribution, not re-authorization.
+        /// <example>
+        /// <code>
+        /// app.SpiderlyUseHangfirePrincipalFilter();
+        /// </code>
+        /// </example>
+        /// </summary>
+        /// <param name="app">The application builder (Configure phase); the filter is registered globally via Hangfire.</param>
+        public static void SpiderlyUseHangfirePrincipalFilter(this IApplicationBuilder app)
+        {
+            IServiceProvider services = app.ApplicationServices;
+            GlobalJobFilters.Filters.Add(new HangfirePrincipalFilter(services.GetRequiredService<ISpiderlyPrincipalAccessor>()));
+        }
+
         #endregion
 
     }

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -2301,6 +2301,8 @@ public class Startup
 
         app.SpiderlyUseHangfireFailedJobNotificationFilter();
 
+        app.SpiderlyUseHangfirePrincipalFilter();
+
         app.SpiderlyUseOutboxRecurringJob<OutboxMessage>();
 
         app.UseHangfireDashboard("/hangfire", new DashboardOptions


### PR DESCRIPTION
Phase 1 of the auth redesign: make the current principal **transport-agnostic** and flow it into background work. Two commits — the keystone accessor, then the Hangfire job-principal filter.

## What

- **`ISpiderlyPrincipalAccessor` + `SpiderlyPrincipal`** (identity-only) in `Spiderly.Shared.Authorization`. Default `SpiderlyPrincipalAccessor` is `AsyncLocal`-backed (singleton, like `IHttpContextAccessor`): prefers an explicitly pushed principal, falls back to the ambient HTTP request's claims. `AuthenticationService.GetCurrentUserId / GetCurrentUserIdOrDefault / GetCurrentPrincipalKind` delegate to it (no direct `HttpContext` reads for identity).
- **`HangfirePrincipalFilter`** (`IClientFilter` + `IServerFilter`): captures the enqueuing principal's id+kind onto the job, restores it onto the accessor for the duration of execution, and defaults to `SpiderlyPrincipal.System` for recurring / scheduler-enqueued jobs. Registered via `app.SpiderlyUseHangfirePrincipalFilter()` (wired into the `spiderly init` template).

## Why

- **Closes the non-HTTP landmine.** `GetCurrentUserId*` in a Hangfire job used to NRE on a null `HttpContext`. Now: anonymous → `GetCurrentUserIdOrDefault()` null / `GetCurrentUserId()` a clear `InvalidOperationException`; and jobs run under a real principal (captured actor, or `System`).
- **Testability.** `accessor.Push(SpiderlyPrincipal.ForUser(42))` — no `HttpContext` mocking.
- **Foundation** for boundary authorization + automatic audit-actor stamping (later phases).

## Design notes

- **Identity only — no permissions.** `SpiderlyPrincipal` carries `UserId / Kind / IsAuthenticated / IsSystem`. Permission resolution stays in the authz layer (`IPrincipalRegistry`); not eagerly loaded here (keeps it a pure identity concern, no per-request permission DB hit).
- **Jobs: attribution, not authorization.** Only id+kind travel with a job — never tokens. Background work is trusted (not re-authorized against the captured principal's live permissions).
- **Non-breaking.** The HTTP fallback means existing apps need no new wiring; `AuthenticationService` keeps its public signatures. `PrincipalClaims` moves to `Spiderly.Shared.Authorization` (Shared can't depend on Security, and the accessor needs the `principal_kind` claim name).

## Tests

`SpiderlyPrincipalAccessorTests` (8): anonymous default, push/restore, nesting, `System`, HTTP-claims fallback, push-precedence, unauthenticated context, null guard. Existing `Spiderly.Shared.Tests` (63) + `Spiderly.Security.Tests` (13) green; full solution builds clean. The Hangfire filter is thin plumbing over the (tested) accessor and follows the existing un-unit-tested `HangfireFailedJobNotificationFilter` convention; the init-template wiring is covered by CI e2e.

## Follow-ups (separate phases / PRs)

- Optional explicit HTTP middleware (the accessor's lazy fallback already covers HTTP).
- **Phase 2** coarse authz to the boundary (dynamic policy provider + convention for CRUD + fail-closed).
- **Phase 3** permission catalog + DB sync; declarative custom permissions.
- **Phase 4** resource / row-level authz (expression rule → query predicate + single-resource eval).
- **Phase 5** audit-actor `ISaveChangesInterceptor` (auto `CreatedBy/ModifiedBy` from the ambient principal).
- Docs: `spiderly-website` page for the principal accessor.
