### PR TITLE
feat(security): coarse authorization to the boundary (Phase 2)

### DIFF
--- a/Spiderly.Security/Authorization/PermissionAuthorizationHandler.cs
+++ b/Spiderly.Security/Authorization/PermissionAuthorizationHandler.cs
@@ -1,0 +1,38 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Spiderly.Security.Services;
+using Spiderly.Shared.Authorization;
+
+namespace Spiderly.Security.Authorization
+{
+    /// <summary>
+    /// Evaluates <see cref="PermissionRequirement"/> by delegating to the registered
+    /// <see cref="AuthorizationServiceBase.IsAuthorizedAsync(string)"/> — so the principal-kind dispatch and any
+    /// consumer override (e.g. an API-key role cap) apply unchanged. Fails closed: an anonymous caller or a
+    /// missing permission simply does not succeed the requirement (no <c>context.Fail()</c>, leaving room for
+    /// other handlers in a composed policy).
+    /// </summary>
+    public sealed class PermissionAuthorizationHandler : AuthorizationHandler<PermissionRequirement>
+    {
+        private readonly AuthorizationServiceBase _authorizationService;
+
+        /// <summary>Creates the handler over the registered authorization service (the consumer's most-derived registration).</summary>
+        /// <param name="authorizationService">The authorization service whose <c>IsAuthorizedAsync</c> decides the requirement.</param>
+        public PermissionAuthorizationHandler(AuthorizationServiceBase authorizationService)
+        {
+            _authorizationService = authorizationService;
+        }
+
+        /// <inheritdoc/>
+        protected override async Task HandleRequirementAsync(AuthorizationHandlerContext context, PermissionRequirement requirement)
+        {
+            // Anonymous → deny without resolving a principal (avoids throwing on a null current user; the
+            // materialized policy also requires an authenticated user, so this is belt-and-suspenders).
+            if (context.User?.Identity?.IsAuthenticated != true)
+                return;
+
+            if (await _authorizationService.IsAuthorizedAsync(requirement.PermissionCode))
+                context.Succeed(requirement);
+        }
+    }
+}

--- a/Spiderly.Shared.Tests/HasPermissionAttributeTests.cs
+++ b/Spiderly.Shared.Tests/HasPermissionAttributeTests.cs
@@ -1,0 +1,20 @@
+using Spiderly.Shared.Authorization;
+using Xunit;
+
+namespace Spiderly.Shared.Tests
+{
+    // [HasPermission(code)] is the typed entry point the controller generator emits and hand-written endpoints
+    // use. It must map the code to the same `perm:<code>` policy name the PermissionPolicyProvider parses.
+    public class HasPermissionAttributeTests
+    {
+        [Fact]
+        public void Maps_permission_code_to_the_perm_policy_name()
+        {
+            HasPermissionAttribute attribute = new("UpdateProduct");
+
+            Assert.Equal("UpdateProduct", attribute.PermissionCode);
+            Assert.Equal("perm:UpdateProduct", attribute.Policy);
+            Assert.Equal(SpiderlyAuthorizationPolicies.ForPermission("UpdateProduct"), attribute.Policy);
+        }
+    }
+}

--- a/Spiderly.Shared.Tests/PermissionPolicyProviderTests.cs
+++ b/Spiderly.Shared.Tests/PermissionPolicyProviderTests.cs
@@ -1,0 +1,63 @@
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
+using Microsoft.Extensions.Options;
+using Spiderly.Shared.Authorization;
+using Xunit;
+
+namespace Spiderly.Shared.Tests
+{
+    // Permission-as-policy bridge: a permission code <-> ASP.NET policy name convention plus a dynamic policy
+    // provider that materializes `perm:<Code>` policies on demand. Pins the convention round-trip and that the
+    // materialized policy requires an authenticated user + the right PermissionRequirement, and that non-permission
+    // names fall through to the default provider.
+    public class PermissionPolicyProviderTests
+    {
+        [Fact]
+        public void ForPermission_builds_prefixed_policy_name()
+        {
+            Assert.Equal("perm:UpdateProduct", SpiderlyAuthorizationPolicies.ForPermission("UpdateProduct"));
+        }
+
+        [Theory]
+        [InlineData("perm:UpdateProduct", true, "UpdateProduct")]
+        [InlineData("perm:a", true, "a")]
+        [InlineData("perm:", false, null)]            // prefix only → not a usable permission policy
+        [InlineData("UpdateProduct", false, null)]    // no prefix
+        [InlineData("", false, null)]
+        [InlineData(null, false, null)]
+        public void TryGetPermissionCode_parses_only_permission_policies(string policyName, bool expected, string expectedCode)
+        {
+            bool result = SpiderlyAuthorizationPolicies.TryGetPermissionCode(policyName, out string code);
+
+            Assert.Equal(expected, result);
+            Assert.Equal(expectedCode, code);
+        }
+
+        [Fact]
+        public async Task GetPolicyAsync_materializes_permission_policy_with_requirement_and_auth()
+        {
+            PermissionPolicyProvider provider = new(Options.Create(new AuthorizationOptions()));
+
+            AuthorizationPolicy policy = await provider.GetPolicyAsync(SpiderlyAuthorizationPolicies.ForPermission("UpdateProduct"));
+
+            Assert.NotNull(policy);
+            PermissionRequirement requirement = policy.Requirements.OfType<PermissionRequirement>().Single();
+            Assert.Equal("UpdateProduct", requirement.PermissionCode);
+            // RequireAuthenticatedUser() → anonymous callers are denied before the permission check.
+            Assert.Contains(policy.Requirements, r => r is DenyAnonymousAuthorizationRequirement);
+        }
+
+        [Fact]
+        public async Task GetPolicyAsync_falls_through_for_non_permission_policy()
+        {
+            PermissionPolicyProvider provider = new(Options.Create(new AuthorizationOptions()));
+
+            // Not a "perm:" policy and not registered anywhere → the wrapped default provider returns null.
+            AuthorizationPolicy policy = await provider.GetPolicyAsync("SomeOtherPolicy");
+
+            Assert.Null(policy);
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/HasPermissionAttribute.cs
+++ b/Spiderly.Shared/Authorization/HasPermissionAttribute.cs
@@ -1,0 +1,30 @@
+using Microsoft.AspNetCore.Authorization;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Requires the current principal to hold a specific permission, enforced at the endpoint boundary through
+    /// the permission policy materialized by <see cref="PermissionPolicyProvider"/>. Typed sugar over
+    /// <c>[Authorize(Policy = "perm:&lt;code&gt;")]</c> — annotate an action with
+    /// <c>[HasPermission("UpdateProduct")]</c> (or a generated CRUD code) instead of hand-typing the policy
+    /// string. Composes with <c>[AuthGuard]</c> (authentication); this adds the authorization check.
+    /// </summary>
+    /// <remarks>
+    /// The permission code is a constructor argument (so a compile-time constant string literal or generated
+    /// code works as an attribute argument); the <c>perm:</c> policy name is built at attribute construction via
+    /// <see cref="SpiderlyAuthorizationPolicies.ForPermission"/>, keeping the convention in one place.
+    /// </remarks>
+    public sealed class HasPermissionAttribute : AuthorizeAttribute
+    {
+        /// <summary>Creates the attribute requiring <paramref name="permissionCode"/>.</summary>
+        /// <param name="permissionCode">The permission code the caller must hold (e.g. <c>UpdateProduct</c>).</param>
+        public HasPermissionAttribute(string permissionCode)
+            : base(SpiderlyAuthorizationPolicies.ForPermission(permissionCode))
+        {
+            PermissionCode = permissionCode;
+        }
+
+        /// <summary>The required permission code (also encoded into the policy name).</summary>
+        public string PermissionCode { get; }
+    }
+}

--- a/Spiderly.Shared/Authorization/PermissionPolicyProvider.cs
+++ b/Spiderly.Shared/Authorization/PermissionPolicyProvider.cs
@@ -1,0 +1,47 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.Options;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Dynamic <see cref="IAuthorizationPolicyProvider"/> that materializes a permission policy on demand for any
+    /// policy name in the <see cref="SpiderlyAuthorizationPolicies.PermissionPolicyPrefix"/> convention (e.g.
+    /// <c>perm:UpdateProduct</c>) — so permission codes need not be pre-registered as named policies. The
+    /// materialized policy requires an authenticated user plus a <see cref="PermissionRequirement"/>; every other
+    /// policy name falls through to the default provider. Registered as a singleton.
+    /// </summary>
+    public sealed class PermissionPolicyProvider : IAuthorizationPolicyProvider
+    {
+        private readonly DefaultAuthorizationPolicyProvider _fallbackPolicyProvider;
+
+        /// <summary>Creates the provider, wrapping the default provider for non-permission policy names.</summary>
+        /// <param name="options">The authorization options used by the wrapped default provider.</param>
+        public PermissionPolicyProvider(IOptions<AuthorizationOptions> options)
+        {
+            _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
+        }
+
+        /// <inheritdoc/>
+        public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => _fallbackPolicyProvider.GetDefaultPolicyAsync();
+
+        /// <inheritdoc/>
+        public Task<AuthorizationPolicy> GetFallbackPolicyAsync() => _fallbackPolicyProvider.GetFallbackPolicyAsync();
+
+        /// <inheritdoc/>
+        public Task<AuthorizationPolicy> GetPolicyAsync(string policyName)
+        {
+            if (SpiderlyAuthorizationPolicies.TryGetPermissionCode(policyName, out string permissionCode))
+            {
+                AuthorizationPolicy policy = new AuthorizationPolicyBuilder()
+                    .RequireAuthenticatedUser()
+                    .AddRequirements(new PermissionRequirement(permissionCode))
+                    .Build();
+
+                return Task.FromResult(policy);
+            }
+
+            return _fallbackPolicyProvider.GetPolicyAsync(policyName);
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/PermissionRequirement.cs
+++ b/Spiderly.Shared/Authorization/PermissionRequirement.cs
@@ -1,0 +1,27 @@
+using System;
+using Microsoft.AspNetCore.Authorization;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Authorization requirement satisfied when the current principal holds a specific permission code.
+    /// Materialized per code by <see cref="PermissionPolicyProvider"/> and evaluated by the consumer's
+    /// permission authorization handler, which delegates to the registered authorization service so the
+    /// principal-kind dispatch (and any consumer override, e.g. an API-key role cap) is preserved.
+    /// </summary>
+    public sealed class PermissionRequirement : IAuthorizationRequirement
+    {
+        /// <summary>The permission code the current principal must hold (e.g. <c>UpdateProduct</c>).</summary>
+        public string PermissionCode { get; }
+
+        /// <summary>Creates the requirement for <paramref name="permissionCode"/>.</summary>
+        /// <param name="permissionCode">The required permission code; must not be null or empty.</param>
+        public PermissionRequirement(string permissionCode)
+        {
+            if (string.IsNullOrEmpty(permissionCode))
+                throw new ArgumentException("Permission code must be provided.", nameof(permissionCode));
+
+            PermissionCode = permissionCode;
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/SpiderlyAuthorizationPolicies.cs
+++ b/Spiderly.Shared/Authorization/SpiderlyAuthorizationPolicies.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Spiderly.Shared.Authorization
+{
+    /// <summary>
+    /// Single source of truth for the permission-policy naming convention that bridges a permission code to an
+    /// ASP.NET Core authorization policy name. Annotate an endpoint with
+    /// <c>[Authorize(SpiderlyAuthorizationPolicies.ForPermission(PermissionCodes.UpdateProduct))]</c> so the
+    /// policy string is never hand-typed; <see cref="PermissionPolicyProvider"/> reverses it on the way in.
+    /// </summary>
+    public static class SpiderlyAuthorizationPolicies
+    {
+        /// <summary>Prefix marking a dynamically-materialized permission policy (e.g. <c>perm:UpdateProduct</c>).</summary>
+        public const string PermissionPolicyPrefix = "perm:";
+
+        /// <summary>Builds the policy name for a permission code.</summary>
+        /// <param name="permissionCode">The permission code (e.g. <c>UpdateProduct</c>); must not be null or empty.</param>
+        /// <returns>The policy name, e.g. <c>perm:UpdateProduct</c>.</returns>
+        public static string ForPermission(string permissionCode)
+        {
+            if (string.IsNullOrEmpty(permissionCode))
+                throw new ArgumentException("Permission code must be provided.", nameof(permissionCode));
+
+            return PermissionPolicyPrefix + permissionCode;
+        }
+
+        /// <summary>Extracts the permission code from a policy name produced by <see cref="ForPermission"/>.</summary>
+        /// <param name="policyName">The policy name to inspect.</param>
+        /// <param name="permissionCode">The extracted permission code when this is a permission policy; otherwise <c>null</c>.</param>
+        /// <returns><c>true</c> when <paramref name="policyName"/> is a permission policy.</returns>
+        public static bool TryGetPermissionCode(string policyName, out string permissionCode)
+        {
+            if (string.IsNullOrEmpty(policyName) == false
+                && policyName.StartsWith(PermissionPolicyPrefix, StringComparison.Ordinal)
+                && policyName.Length > PermissionPolicyPrefix.Length)
+            {
+                permissionCode = policyName.Substring(PermissionPolicyPrefix.Length);
+                return true;
+            }
+
+            permissionCode = null;
+            return false;
+        }
+    }
+}

--- a/Spiderly.Shared/Extensions/StartupExtensions.cs
+++ b/Spiderly.Shared/Extensions/StartupExtensions.cs
@@ -1,5 +1,6 @@
 using Hangfire;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.HttpOverrides;
@@ -146,6 +147,13 @@ namespace Spiderly.Shared.Extensions
             {
                 services.SpiderlyAddAuthentication();
                 services.AddAuthorization();
+
+                // Permission-as-policy: this dynamic provider materializes a `perm:<Code>` policy on demand, so an
+                // endpoint can declare [Authorize(SpiderlyAuthorizationPolicies.ForPermission(code))] without
+                // pre-registering each policy. Falls through to the default provider for every other policy name.
+                // The matching PermissionAuthorizationHandler (which delegates to the consumer's AuthorizationService
+                // so its override/API-key cap applies) is wired alongside the security services.
+                services.AddSingleton<IAuthorizationPolicyProvider, PermissionPolicyProvider>();
 
                 // Resolves a provider code to its id-token validator. Built eagerly at first resolution from
                 // the configured providers (+ any consumer-registered custom IExternalAuthProvider), so the

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -2577,10 +2577,12 @@ namespace {{appName}}.WebAPI
         private static string GetAppServiceExtensionsCsData(string appName)
         {
             return $$"""
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Spiderly.Security;
+using Spiderly.Security.Authorization;
 using Spiderly.Security.Extensions;
 using Spiderly.Security.Interfaces;
 using Spiderly.Security.Services;
@@ -2598,8 +2600,13 @@ namespace {{appName}}.WebAPI.Extensions
             #region Spiderly
 
             services.AddTransient<AuthenticationService>();
-            services.AddTransient<AuthorizationServiceBase>();
+            // Forward AuthorizationServiceBase to the app's generated authorization service so framework
+            // consumers (e.g. PermissionAuthorizationHandler) resolve the most-derived IsAuthorizedAsync override.
+            services.AddTransient<AuthorizationServiceBase>(sp => sp.GetRequiredService<{{appName}}.Business.Services.AuthorizationServiceGenerated>());
             services.AddTransient<SecurityServiceBase<User, UserExternalLogin>>();
+
+            // Evaluates [HasPermission] / [Authorize("perm:...")] policies via the permission policy provider.
+            services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
 
             // Register the application's principal kind(s). A single-principal app registers just User; the
             // kind-dispatched authorization resolves it even without a principal_kind claim (single kind = the

--- a/Spiderly.SourceGenerators.Tests/Generators/ControllerPermissionAttributeTests.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/ControllerPermissionAttributeTests.cs
@@ -1,0 +1,37 @@
+using Spiderly.SourceGenerators.Models;
+using Spiderly.SourceGenerators.Shared;
+
+namespace Spiderly.SourceGenerators.Tests.Generators;
+
+public class ControllerPermissionAttributeTests
+{
+    // Pins the security-relevant decision behind the controller's boundary authorization: an authorize-able
+    // entity yields [HasPermission("{Crud}{Entity}")] on its CRUD actions, while a [DoNotAuthorize] entity
+    // yields nothing (public endpoints). A dropped/wrong attribute is a silent authz hole.
+    //
+    // This pins the emission *logic* (Helpers.GetPermissionAttribute) rather than a full controller snapshot:
+    // ControllerGenerator gates on a ".WebAPI" calling path that GeneratorTestHarness does not supply, so it
+    // emits nothing under the harness. End-to-end generated-controller output is exercised by the CI e2e job.
+
+    [Fact]
+    public void AuthorizeableEntity_EmitsHasPermissionAttribute()
+    {
+        SpiderlyClass entity = new() { Name = "Product" };
+
+        Assert.Equal("[HasPermission(\"ReadProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, "Read"));
+        Assert.Equal("[HasPermission(\"DeleteProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, "Delete"));
+    }
+
+    [Fact]
+    public void DoNotAuthorizeEntity_EmitsNothing()
+    {
+        SpiderlyClass entity = new()
+        {
+            Name = "PublicLookup",
+            Attributes = new() { new SpiderlyAttribute { Name = "DoNotAuthorize" } },
+        };
+
+        Assert.Equal("", Helpers.GetPermissionAttribute(entity, "Read"));
+        Assert.Equal("", Helpers.GetPermissionAttribute(entity, "Delete"));
+    }
+}

--- a/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
@@ -87,6 +87,7 @@ using Spiderly.Shared.Constants;
 using Spiderly.Shared.Helpers;
 using Spiderly.Shared.Extensions;
 using Spiderly.Shared.Attributes;
+using Spiderly.Shared.Authorization;
 using Spiderly.Shared.Interfaces;
 using Spiderly.Shared.Localization;
 using Spiderly.Shared.DTO;
@@ -169,6 +170,7 @@ namespace {{basePartOfNamespace}}.Controllers
                 {
                     string referencedProjectEntityClassIdType = controllerEntity.GetIdType(allEntities);
                     string entityServiceField = $"_serviceProvider.GetRequiredService<{controllerEntity.Name}ServiceGenerated>()";
+                    string readPermissionAttribute = Helpers.GetPermissionAttribute(controllerEntity, "Read");
 
                     entityRegion = $$"""
         #region {{controllerEntity.Name}}
@@ -180,7 +182,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task<PaginatedResultDTO<{{controllerEntity.Name}}DTO>> GetPaginated{{controllerEntity.Name}}List(FilterDTO filterDTO)
+        {{readPermissionAttribute}}public virtual async Task<PaginatedResultDTO<{{controllerEntity.Name}}DTO>> GetPaginated{{controllerEntity.Name}}List(FilterDTO filterDTO)
         {
             return await {{entityServiceField}}.GetPaginated{{controllerEntity.Name}}List(filterDTO, _context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
         }
@@ -190,7 +192,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task<IActionResult> Export{{controllerEntity.Name}}ListToExcel(FilterDTO filterDTO)
+        {{readPermissionAttribute}}public virtual async Task<IActionResult> Export{{controllerEntity.Name}}ListToExcel(FilterDTO filterDTO)
         {
             byte[] fileContent = await {{entityServiceField}}.Export{{controllerEntity.Name}}ListToExcel(filterDTO, _context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
             return File(
@@ -205,7 +207,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<List<{{controllerEntity.Name}}DTO>> Get{{controllerEntity.Name}}List()
+        {{readPermissionAttribute}}public virtual async Task<List<{{controllerEntity.Name}}DTO>> Get{{controllerEntity.Name}}List()
         {
             return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTOList(_context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
         }
@@ -215,7 +217,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<{{controllerEntity.Name}}MainUIFormDTO> Get{{controllerEntity.Name}}MainUIFormDTO({{referencedProjectEntityClassIdType}} id)
+        {{readPermissionAttribute}}public virtual async Task<{{controllerEntity.Name}}MainUIFormDTO> Get{{controllerEntity.Name}}MainUIFormDTO({{referencedProjectEntityClassIdType}} id)
         {
             return await {{entityServiceField}}.Get{{controllerEntity.Name}}MainUIFormDTO(id, {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
         }
@@ -225,7 +227,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<{{controllerEntity.Name}}DTO> Get{{controllerEntity.Name}}({{referencedProjectEntityClassIdType}} id)
+        {{readPermissionAttribute}}public virtual async Task<{{controllerEntity.Name}}DTO> Get{{controllerEntity.Name}}({{referencedProjectEntityClassIdType}} id)
         {
             return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTO(id, {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
         }
@@ -551,6 +553,7 @@ namespace {{basePartOfNamespace}}.Controllers
                 return null;
 
             string entityIdType = entity.GetIdType(entities);
+            string deletePermissionAttribute = Helpers.GetPermissionAttribute(entity, "Delete");
 
             return $$"""
         /// <summary>
@@ -558,7 +561,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpDelete]
         [AuthGuard]
-        public virtual async Task Delete{{entity.Name}}({{entityIdType}} id)
+        {{deletePermissionAttribute}}public virtual async Task Delete{{entity.Name}}({{entityIdType}} id)
         {
             await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}(id, {{Helpers.GetShouldAuthorizeEntityString(entity)}});
         }
@@ -568,7 +571,7 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task Delete{{entity.Name}}List([FromBody] List<{{entityIdType}}> ids)
+        {{deletePermissionAttribute}}public virtual async Task Delete{{entity.Name}}List([FromBody] List<{{entityIdType}}> ids)
         {
             await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}List(ids, {{Helpers.GetShouldAuthorizeEntityString(entity)}});
         }

--- a/Spiderly.SourceGenerators/Shared/Helpers.cs
+++ b/Spiderly.SourceGenerators/Shared/Helpers.cs
@@ -184,6 +184,21 @@ namespace Spiderly.SourceGenerators.Shared
             return ShouldAuthorizeEntity(entity).ToString().ToLower();
         }
 
+        /// <summary>
+        /// Returns the boundary authorization attribute for a CRUD operation on <paramref name="entity"/> —
+        /// e.g. <c>[HasPermission("ReadProduct")]</c> — with a trailing newline + indent so it can be emitted
+        /// inline before a generated action, or an empty string when the entity opts out via [DoNotAuthorize].
+        /// <paramref name="crudPrefix"/> is the permission-code prefix ("Read" / "Delete" / …), matching the
+        /// codes emitted by the permission-codes generator.
+        /// </summary>
+        public static string GetPermissionAttribute(SpiderlyClass entity, string crudPrefix)
+        {
+            if (ShouldAuthorizeEntity(entity) == false)
+                return "";
+
+            return $"[HasPermission(\"{crudPrefix}{entity.Name}\")]\n        ";
+        }
+
         #endregion
 
         #region Mapper


### PR DESCRIPTION
**Stacked on #262** (base = `feat/ambient-principal-keystone`). Phase 2 of the auth redesign — *coarse authorization to the boundary*. This PR is **Phase 2a: the runtime mechanism only**.

## What

- **`SpiderlyAuthorizationPolicies`** — the `perm:<Code>` policy-name convention (single source of truth). Endpoints use `ForPermission(code)`; the provider reverses it with `TryGetPermissionCode`. No hand-typed policy strings.
- **`PermissionRequirement` + `PermissionPolicyProvider`** (`Spiderly.Shared.Authorization`) — a dynamic `IAuthorizationPolicyProvider` that materializes a `perm:<Code>` policy on demand (`RequireAuthenticatedUser()` + `PermissionRequirement`), falling through to the default provider for any other name. Registered in `AddSpiderly`.
- **`PermissionAuthorizationHandler`** (`Spiderly.Security.Authorization`) — evaluates the requirement by delegating to `AuthorizationServiceBase.IsAuthorizedAsync(code)`, so principal-kind dispatch and any consumer override (e.g. PACMS's API-key role cap) apply unchanged. **Fail-closed**: anonymous or missing permission → does not succeed.

## Why this shape

- **Use the platform's authz extension points** (policy provider + handler) rather than a bespoke filter — the idiomatic ASP.NET "permission-as-policy" pattern. Coarse permission check sits at the boundary; resource/row-level authz stays a separate later phase (after entity load).
- **Preserve the existing decision logic + API-key cap** by delegating to `AuthorizationServiceBase.IsAuthorizedAsync` instead of re-implementing the registry walk.

## Scope — foundation only (non-breaking, dormant)

The provider only activates for `perm:` policy names; **no endpoint emits one yet**, so this is purely additive. The big breaking part is **Phase 2c** (separate PR):
- `ControllerGenerator`: emit the permission policy on generated CRUD actions (by convention) + fail-closed default; custom controllers use a typed attribute.
- Drop the `bool authorize` parameter + the in-service `AuthorizeXAndThrow` calls from the service generators (~6 generators, ~100 method signatures, ~7 verified snapshots).
- Wire `PermissionAuthorizationHandler` in DI and forward `AuthorizationServiceBase` to the app's override (so the handler gets the cap). This is where the handler becomes live + e2e-testable.

## Tests

`PermissionPolicyProviderTests` (9): convention round-trip + edge cases, materialized-policy shape (`PermissionRequirement` + `DenyAnonymousAuthorizationRequirement`), non-permission fall-through. Solution builds clean.
