### PR TITLE
fix(generators): partial {Entity}DTO extensions surface in codegen without [SpiderlyDTO]

### DIFF
--- a/Angular/projects/spiderly/agent/docs/mapper-customization/SKILL.md
+++ b/Angular/projects/spiderly/agent/docs/mapper-customization/SKILL.md
@@ -49,6 +49,34 @@ public class Achievement : BusinessObject<long>
 
 The string is appended directly to the generated `.NewConfig<Entity, EntityDTO>()` chain. Use this for simple field mappings that the generator doesn't produce automatically.
 
+### `[ProjectToDTO]` only fills the value — the field must exist on the DTO
+
+`[ProjectToDTO]` adds a Mapster *mapping*; it does **not** create the property. If `dest.ProductId`
+is not a property on the DTO, the field **never appears in the generated Angular type**
+(`entities.generated.ts`) — `[ProjectToDTO]` fills a value that has nowhere to land. (A common
+false alarm: the value maps fine at runtime, so it looks like the frontend "didn't regenerate" —
+but a normal `dotnet build` *does* regenerate the Angular files; the property was just never on
+the DTO for the generator to emit.)
+
+To add a computed/projected field end-to-end, declare the property on a `partial class {Entity}DTO`
+extension — it merges into the generated DTO automatically, no attribute needed — **then** map its value:
+
+```csharp
+// 1. The property — a partial extension of the generated OrderItemDTO. No [SpiderlyDTO]
+//    needed: a partial that extends a generated DTO is merged in by name.
+public partial class OrderItemDTO
+{
+    public int? ProductId { get; set; }
+}
+
+// 2. The value — [ProjectToDTO] on the entity fills it during projection.
+[ProjectToDTO(".Map(dest => dest.ProductId, src => src.ProductVariant.ProductId)")]
+public class OrderItem : BusinessObject<long> { /* ... */ }
+```
+
+Then `dotnet build` the backend — the source generators run on build and the field appears
+in `entities.generated.ts`. There is no separate "regenerate" command; the build is it.
+
 ## Partial Method Override — Full Control
 
 For complex mapping logic, override the entire generated method. The generator **skips generation** for any method that already exists in the user's partial `Mapper` class (detected by method name match).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,7 +75,7 @@ Never hand-edit anything under `agent/`. The generator fails loud if a skill fol
 - **Hand-written classes require classification attributes.** Source generators enroll classes by marker attribute, not by namespace suffix:
   - Entities → `[SpiderlyEntity]`
   - M2M junction classes → `[M2M]` **and** `[SpiderlyEntity]` (both required — `[M2M]` flags the junction; `[SpiderlyEntity]` enrolls it for generation)
-  - Hand-written DTOs → `[SpiderlyDTO]` (generated DTOs like `{Entity}DTO` / `{Entity}SaveBodyDTO` / `{Entity}MainUIFormDTO` need no attribute)
+  - Hand-written **standalone** DTOs → `[SpiderlyDTO]`. The generated declarations (`{Entity}DTO` / `{Entity}SaveBodyDTO` / `{Entity}MainUIFormDTO`) need no attribute — and neither does a hand-written `partial class {Entity}DTO` that merely **extends** one to add a property: such a partial is merged into the generated DTO by name (`PipelineFactory` enrolls it, `GetDTOClasses` merges it), so its members reach every artifact generator. `[SpiderlyDTO]` is required only for a brand-new DTO that does not extend a generated one.
   - Custom controllers → `[SpiderlyController]`
   - Entity services extending `{Entity}ServiceGenerated` → `[SpiderlyService]`
   - The hand-written partial mapper class → `[SpiderlyDataMapper]`

--- a/Spiderly.SourceGenerators.Tests/Generators/DtoPartialExtensionTests.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/DtoPartialExtensionTests.cs
@@ -1,0 +1,82 @@
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Spiderly.SourceGenerators.Enums;
+using Spiderly.SourceGenerators.Models;
+using Spiderly.SourceGenerators.Shared;
+using Xunit;
+
+namespace Spiderly.SourceGenerators.Tests.Generators;
+
+/// <summary>
+/// A hand-written `partial class {Entity}DTO` that extends a generated DTO must contribute its members to
+/// codegen even when the author forgot `[SpiderlyDTO]`. Before the fix the unmarked partial was silently
+/// dropped from every artifact generator (entities.generated.ts, validators, ...): the field compiled and
+/// serialized but never reached the generated frontend type. (spiderly#258)
+/// </summary>
+public class DtoPartialExtensionTests
+{
+    /// <summary>
+    /// Collection half: an unmarked `partial class {X}DTO` must be enrolled for the DTO category, so it
+    /// reaches <see cref="SpiderlyClassFactory.GetDTOClasses"/>. A *non-partial* unmarked `*DTO` is NOT
+    /// enrolled — a standalone DTO still needs `[SpiderlyDTO]`.
+    /// </summary>
+    [Fact]
+    public void IsClassSyntaxTargetForGeneration_UnmarkedPartialDtoClass_IsEnrolledForDtoCategory()
+    {
+        List<ClassCategoryCodes> dtoCategory = new() { ClassCategoryCodes.DTO };
+
+        Assert.True(SyntaxTargets("public partial class OrderItemDTO { public int ProductId { get; set; } }"));
+        Assert.False(SyntaxTargets("public class StandaloneDTO { public int X { get; set; } }"));   // non-partial, unmarked -> still needs [SpiderlyDTO]
+        Assert.False(SyntaxTargets("public partial class OrderItem { public int Quantity { get; set; } }")); // not a *DTO
+
+        bool SyntaxTargets(string source)
+        {
+            ClassDeclarationSyntax node = CSharpSyntaxTree.ParseText(source)
+                .GetRoot().DescendantNodes().OfType<ClassDeclarationSyntax>().First();
+            return PipelineFactory.IsClassSyntaxTargetForGeneration(node, dtoCategory);
+        }
+    }
+
+    /// <summary>
+    /// Merge half: given an entity (which generates {Entity}DTO) plus an UNMARKED `partial class {Entity}DTO`
+    /// that adds a property, <see cref="SpiderlyClassFactory.GetDTOClasses"/> must surface that property under
+    /// the DTO's name — the same already-handled "two same-named entries" shape a `[SpiderlyDTO]` partial produces.
+    /// </summary>
+    [Fact]
+    public void GetDTOClasses_UnmarkedPartialExtensionOfGeneratedDTO_MergesItsProperties()
+    {
+        SpiderlyClass entity = new()
+        {
+            Name = "OrderItem",
+            Namespace = "Test.Business.Entities",
+            BaseType = "BusinessObject<long>",
+            Attributes = new List<SpiderlyAttribute> { new() { Name = "SpiderlyEntity" } },
+            Properties = new List<SpiderlyProperty> { new() { Name = "Quantity", Type = "int" } },
+        };
+
+        // Hand-written extension that adds ProductId but FORGOT [SpiderlyDTO].
+        SpiderlyClass unmarkedPartial = new()
+        {
+            Name = "OrderItemDTO",
+            Namespace = "Test.Business.DTO",
+            Attributes = new List<SpiderlyAttribute>(),
+            Properties = new List<SpiderlyProperty> { new() { Name = "ProductId", Type = "int?" } },
+        };
+
+        List<SpiderlyClass> input = new() { entity, unmarkedPartial };
+
+        List<SpiderlyClass> dtoClasses = SpiderlyClassFactory.GetDTOClasses(input, input);
+
+        // NgEntitiesGenerator groups DTO entries by name and concatenates their properties; the merged
+        // OrderItemDTO must therefore contain ProductId.
+        List<string> mergedOrderItemDtoProps = dtoClasses
+            .Where(d => d.Name == "OrderItemDTO")
+            .SelectMany(d => d.Properties)
+            .Select(p => p.Name)
+            .ToList();
+
+        Assert.Contains("ProductId", mergedOrderItemDtoProps);
+    }
+}

--- a/Spiderly.SourceGenerators/Shared/Extensions.cs
+++ b/Spiderly.SourceGenerators/Shared/Extensions.cs
@@ -293,6 +293,11 @@ namespace Spiderly.SourceGenerators.Shared
             return c.Modifiers.Any(x => x.Text == "abstract");
         }
 
+        public static bool IsPartial(this ClassDeclarationSyntax c)
+        {
+            return c.Modifiers.Any(x => x.Text == "partial");
+        }
+
         /// <summary>
         /// User : BusinessObject<long> -> true
         /// User : ReadonlyObject<long> -> false

--- a/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
@@ -38,18 +38,22 @@ namespace Spiderly.SourceGenerators.Shared
             {
                 if (HasAttributeByName(classDeclaration, GetMarkerAttributeName(category)))
                     return true;
-
-                // A hand-written `partial class {Entity}DTO` that extends a generated DTO is enrolled even
-                // without [SpiderlyDTO], so the members it adds aren't silently dropped from codegen
-                // (spiderly#258). Scoped to partial *DTO declarations; GetDTOClasses further narrows the merge
-                // to names that match a generated DTO, so a standalone unmarked DTO still requires the marker.
-                if (category == ClassCategoryCodes.DTO
-                    && classDeclaration.Identifier.Text.EndsWith(Helpers.DTONamespaceEnding)
-                    && classDeclaration.IsPartial())
-                    return true;
             }
 
+            // A hand-written `partial class {Entity}DTO` that extends a generated DTO is enrolled even without
+            // [SpiderlyDTO], so the members it adds aren't silently dropped from codegen (spiderly#258). Scoped
+            // to partial *DTO declarations; GetDTOClasses further narrows the merge to names that match a
+            // generated DTO, so a standalone unmarked DTO still requires the marker.
+            if (categories.Contains(ClassCategoryCodes.DTO) && IsPartialDtoClass(classDeclaration))
+                return true;
+
             return false;
+        }
+
+        private static bool IsPartialDtoClass(ClassDeclarationSyntax classDeclaration)
+        {
+            return classDeclaration.Identifier.Text.EndsWith(Helpers.DTONamespaceEnding)
+                && classDeclaration.IsPartial();
         }
 
         public static string GetMarkerAttributeName(ClassCategoryCodes category) => category switch

--- a/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/PipelineFactory.cs
@@ -38,6 +38,15 @@ namespace Spiderly.SourceGenerators.Shared
             {
                 if (HasAttributeByName(classDeclaration, GetMarkerAttributeName(category)))
                     return true;
+
+                // A hand-written `partial class {Entity}DTO` that extends a generated DTO is enrolled even
+                // without [SpiderlyDTO], so the members it adds aren't silently dropped from codegen
+                // (spiderly#258). Scoped to partial *DTO declarations; GetDTOClasses further narrows the merge
+                // to names that match a generated DTO, so a standalone unmarked DTO still requires the marker.
+                if (category == ClassCategoryCodes.DTO
+                    && classDeclaration.Identifier.Text.EndsWith(Helpers.DTONamespaceEnding)
+                    && classDeclaration.IsPartial())
+                    return true;
             }
 
             return false;

--- a/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
+++ b/Spiderly.SourceGenerators/Shared/SpiderlyClassFactory.cs
@@ -66,18 +66,7 @@ namespace Spiderly.SourceGenerators.Shared
             {
                 if (x.HasSpiderlyDTOAttribute())
                 {
-                    DTOList.Add(new SpiderlyClass
-                    {
-                        Name = x.Name,
-                        Properties = x.Properties,
-                        Attributes = x.Attributes,
-                        BaseType = x.BaseType,
-                        IsAbstract = x.IsAbstract,
-                        Methods = x.Methods,
-                        Namespace = x.Namespace,
-                        Location = x.Location,
-                        IsGenerated = false,
-                    });
+                    DTOList.Add(ToHandWrittenDTO(x));
                 }
                 else if (x.HasSpiderlyEntityAttribute())
                 {
@@ -112,8 +101,46 @@ namespace Spiderly.SourceGenerators.Shared
                 }
             }
 
+            // Merge hand-written `partial class {Entity}DTO` extensions that omitted [SpiderlyDTO]: they carry
+            // the same name as a DTO Spiderly generates from an entity, so without this their members are
+            // silently dropped from every artifact generator (entities.generated.ts, validators, ...) —
+            // the field compiles and serializes but never reaches the generated artifacts (spiderly#258).
+            // Scoped to those generated names, so a standalone unmarked DTO still requires the marker. This
+            // produces the same two-same-named-entries shape a [SpiderlyDTO] partial already does, which the
+            // downstream callers (NgEntities, FluentValidation, Mapper, ...) group and merge.
+            HashSet<string> generatedDTONames = new(DTOList.Where(d => d.IsGenerated).Select(d => d.Name));
+
+            foreach (var x in currentProjectClasses)
+            {
+                if (x.HasSpiderlyDTOAttribute() || x.HasSpiderlyEntityAttribute())
+                    continue;
+
+                if (generatedDTONames.Contains(x.Name) == false)
+                    continue;
+
+                DTOList.Add(ToHandWrittenDTO(x));
+            }
+
             return DTOList;
         }
+
+        /// <summary>
+        /// Projects a hand-written DTO class — a `[SpiderlyDTO]` class or an unmarked `partial {Entity}DTO`
+        /// extension — into the DTO list verbatim, flagged non-generated so callers merge it with the
+        /// entity-derived DTO of the same name.
+        /// </summary>
+        private static SpiderlyClass ToHandWrittenDTO(SpiderlyClass x) => new()
+        {
+            Name = x.Name,
+            Properties = x.Properties,
+            Attributes = x.Attributes,
+            BaseType = x.BaseType,
+            IsAbstract = x.IsAbstract,
+            Methods = x.Methods,
+            Namespace = x.Namespace,
+            Location = x.Location,
+            IsGenerated = false,
+        };
 
         private static string GetDtoNamespaceForEntity(string entityNamespace)
         {

--- a/claude-plugins/skills/mapper-customization/SKILL.md
+++ b/claude-plugins/skills/mapper-customization/SKILL.md
@@ -49,6 +49,34 @@ public class Achievement : BusinessObject<long>
 
 The string is appended directly to the generated `.NewConfig<Entity, EntityDTO>()` chain. Use this for simple field mappings that the generator doesn't produce automatically.
 
+### `[ProjectToDTO]` only fills the value — the field must exist on the DTO
+
+`[ProjectToDTO]` adds a Mapster *mapping*; it does **not** create the property. If `dest.ProductId`
+is not a property on the DTO, the field **never appears in the generated Angular type**
+(`entities.generated.ts`) — `[ProjectToDTO]` fills a value that has nowhere to land. (A common
+false alarm: the value maps fine at runtime, so it looks like the frontend "didn't regenerate" —
+but a normal `dotnet build` *does* regenerate the Angular files; the property was just never on
+the DTO for the generator to emit.)
+
+To add a computed/projected field end-to-end, declare the property on a `partial class {Entity}DTO`
+extension — it merges into the generated DTO automatically, no attribute needed — **then** map its value:
+
+```csharp
+// 1. The property — a partial extension of the generated OrderItemDTO. No [SpiderlyDTO]
+//    needed: a partial that extends a generated DTO is merged in by name.
+public partial class OrderItemDTO
+{
+    public int? ProductId { get; set; }
+}
+
+// 2. The value — [ProjectToDTO] on the entity fills it during projection.
+[ProjectToDTO(".Map(dest => dest.ProductId, src => src.ProductVariant.ProductId)")]
+public class OrderItem : BusinessObject<long> { /* ... */ }
+```
+
+Then `dotnet build` the backend — the source generators run on build and the field appears
+in `entities.generated.ts`. There is no separate "regenerate" command; the build is it.
+
 ## Partial Method Override — Full Control
 
 For complex mapping logic, override the entire generated method. The generator **skips generation** for any method that already exists in the user's partial `Mapper` class (detected by method name match).


### PR DESCRIPTION
## What

A hand-written `partial class {Entity}DTO` that extends a generated DTO now surfaces in the generated artifacts (`entities.generated.ts`, validators, …) **without** requiring `[SpiderlyDTO]`. Previously the marker was silently required — forget it and the member compiled and serialized but vanished from codegen, with no error or warning.

## Why (the #258 story)

#258 reported "no command to regenerate generated files after changing an existing entity/DTO." That premise is a **misdiagnosis**: `dotnet build` *does* re-run the Angular generators. The real cause was that the field was added via `[ProjectToDTO]` + an **unmarked** partial DTO — `[ProjectToDTO]` only maps the value (Mapster), and the unmarked partial was dropped by the marker-gated collection. No `regenerate` command would have helped; the fix is to stop dropping the partial.

Reproduced on a real consumer: same partial, only delta = the `[SpiderlyDTO]` line — without it the field was absent from `entities.generated.ts`; with it, present, after a plain `dotnet build`.

## The fix

- `PipelineFactory.MatchesCategories` — enroll an unmarked `partial *DTO` for the DTO category.
- `SpiderlyClassFactory.GetDTOClasses` — merge such a partial **only when its name matches a DTO generated from an entity**, so a standalone unmarked DTO still requires `[SpiderlyDTO]`.
- Reuses the same "two same-named entries" shape a marked partial already produces, so all 7 `GetDTOClasses` consumers (NgEntities, NgControllers, FluentValidation, Mapper, Excel, PaginatedResult, EntitiesToDTO) handle it unchanged.

## Docs

`mapper-customization` skill + contributor `CLAUDE.md`: a partial extension auto-merges (no marker); `[ProjectToDTO]` fills a value but does not create the property. Regenerated the shipped agent bundle.

## Tests

- New `DtoPartialExtensionTests` covers both halves (syntax enrollment + the merge). Committed **before** the fix, so it is red on its own commit and green on the fix commit (per the repo's regression-test rule).
- Full source-generator suite: **379/379 green**.

## Notes / follow-ups

- Addresses #258 — recommend closing it with a short comment explaining the misdiagnosis once this lands.
- `spiderly-website` DTO docs should get the same clarification (separate repo).
- A genuine "C#-only DTO member" opt-out (honor `[JsonIgnore]` uniformly) does not exist today even for marked partials; if wanted, that is a separate small feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)