### PR TITLE
Phase 2d: drop in-service read/delete authz + boundary [HasPermission] on nested reads

### DIFF
--- a/Spiderly.Security/Extensions/AuthorizationRegistrationExtensions.cs
+++ b/Spiderly.Security/Extensions/AuthorizationRegistrationExtensions.cs
@@ -1,0 +1,35 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.Extensions.DependencyInjection;
+using Spiderly.Security.Authorization;
+using Spiderly.Security.Services;
+
+namespace Spiderly.Security.Extensions
+{
+    /// <summary>
+    /// Registers the permission-as-policy authorization that pairs with the framework's
+    /// <c>PermissionPolicyProvider</c> (wired in <c>AddSpiderly</c>). Lives here, not in the init template, so the
+    /// two coupled registrations stay together and framework-owned — the <see cref="PermissionAuthorizationHandler"/>
+    /// can't drift from the provider, and the <see cref="AuthorizationServiceBase"/> forwarding can't be forgotten.
+    /// </summary>
+    public static class AuthorizationRegistrationExtensions
+    {
+        /// <summary>
+        /// Registers the <c>[HasPermission]</c> handler and forwards the framework's <see cref="AuthorizationServiceBase"/>
+        /// to <typeparamref name="TAuthorizationService"/> — the application's generated / most-derived authorization
+        /// service — so the handler evaluates that service's <c>IsAuthorizedAsync</c> override (and any API-key cap).
+        /// </summary>
+        /// <typeparam name="TAuthorizationService">The app's authorization service registered in DI (e.g. <c>AuthorizationServiceGenerated</c>).</typeparam>
+        public static IServiceCollection AddSpiderlyAuthorization<TAuthorizationService>(this IServiceCollection services)
+            where TAuthorizationService : AuthorizationServiceBase
+        {
+            // Forward AuthorizationServiceBase to the app's generated authorization service so framework consumers
+            // (PermissionAuthorizationHandler) resolve the most-derived IsAuthorizedAsync override.
+            services.AddTransient<AuthorizationServiceBase>(sp => sp.GetRequiredService<TAuthorizationService>());
+
+            // Evaluates [HasPermission] / [Authorize("perm:...")] policies materialized by PermissionPolicyProvider.
+            services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
+
+            return services;
+        }
+    }
+}

--- a/Spiderly.Shared/Authorization/HangfirePrincipalFilter.cs
+++ b/Spiderly.Shared/Authorization/HangfirePrincipalFilter.cs
@@ -40,7 +40,7 @@ namespace Spiderly.Shared.Authorization
         public void OnCreating(CreatingContext context)
         {
             SpiderlyPrincipal current = _principalAccessor.Current;
-            if (current.IsAuthenticated == false || current.UserId.HasValue == false)
+            if (current.UserId.HasValue == false)
                 return;
 
             context.SetJobParameter(UserIdParameter, current.UserId.Value);

--- a/Spiderly.Shared/Authorization/PermissionPolicyProvider.cs
+++ b/Spiderly.Shared/Authorization/PermissionPolicyProvider.cs
@@ -22,6 +22,16 @@ namespace Spiderly.Shared.Authorization
             _fallbackPolicyProvider = new DefaultAuthorizationPolicyProvider(options);
         }
 
+        /// <summary>
+        /// Opts into the framework's per-endpoint policy cache. The <c>perm:&lt;code&gt;</c> policies materialized here
+        /// are deterministic per policy name (same requirement set every time), and the per-user permission check runs
+        /// on every request in the <c>PermissionAuthorizationHandler</c> regardless — so caching the static policy
+        /// shape is safe and avoids rebuilding it (and the combined policy) on every authorized request. Without this,
+        /// <c>AuthorizationMiddleware</c> bypasses its cache for this provider and calls <see cref="GetPolicyAsync"/>
+        /// per request (the default-interface value is <c>false</c> for any non-<c>DefaultAuthorizationPolicyProvider</c>).
+        /// </summary>
+        public bool AllowsCachingPolicies => true;
+
         /// <inheritdoc/>
         public Task<AuthorizationPolicy> GetDefaultPolicyAsync() => _fallbackPolicyProvider.GetDefaultPolicyAsync();
 

--- a/Spiderly.Shared/Authorization/SpiderlyPrincipal.cs
+++ b/Spiderly.Shared/Authorization/SpiderlyPrincipal.cs
@@ -18,8 +18,8 @@ namespace Spiderly.Shared.Authorization
         /// </summary>
         public string Kind { get; }
 
-        /// <summary>True when this principal represents an authenticated end user (has a <see cref="UserId"/>).</summary>
-        public bool IsAuthenticated { get; }
+        /// <summary>True when this principal represents an authenticated end user — i.e. it carries a <see cref="UserId"/>.</summary>
+        public bool IsAuthenticated => UserId.HasValue;
 
         /// <summary>
         /// True when this principal represents trusted background/system execution with no end user
@@ -27,11 +27,10 @@ namespace Spiderly.Shared.Authorization
         /// </summary>
         public bool IsSystem { get; }
 
-        private SpiderlyPrincipal(long? userId, string kind, bool isAuthenticated, bool isSystem)
+        private SpiderlyPrincipal(long? userId, string kind, bool isSystem)
         {
             UserId = userId;
             Kind = kind;
-            IsAuthenticated = isAuthenticated;
             IsSystem = isSystem;
         }
 
@@ -40,20 +39,20 @@ namespace Spiderly.Shared.Authorization
         /// background job before any actor is pushed). <see cref="IsAuthenticated"/> and <see cref="IsSystem"/>
         /// are both <c>false</c> and <see cref="UserId"/> is <c>null</c>.
         /// </summary>
-        public static readonly SpiderlyPrincipal Anonymous = new(userId: null, kind: null, isAuthenticated: false, isSystem: false);
+        public static readonly SpiderlyPrincipal Anonymous = new(userId: null, kind: null, isSystem: false);
 
         /// <summary>
         /// Trusted background/system execution with no end user (e.g. a recurring Hangfire job). Use this as the
         /// pushed principal for system-initiated work so audit attributes to "system" and authorization can
         /// treat <see cref="IsSystem"/> as a bypass.
         /// </summary>
-        public static readonly SpiderlyPrincipal System = new(userId: null, kind: null, isAuthenticated: false, isSystem: true);
+        public static readonly SpiderlyPrincipal System = new(userId: null, kind: null, isSystem: true);
 
         /// <summary>Creates an authenticated end-user principal.</summary>
         /// <param name="userId">The authenticated user's id (subject).</param>
         /// <param name="kind">The principal kind, or <c>null</c> for the single-principal default.</param>
         /// <returns>A principal with <see cref="IsAuthenticated"/> set to <c>true</c>.</returns>
         public static SpiderlyPrincipal ForUser(long userId, string kind = null) =>
-            new(userId, kind, isAuthenticated: true, isSystem: false);
+            new(userId, kind, isSystem: false);
     }
 }

--- a/Spiderly.Shared/Authorization/SpiderlyPrincipalAccessor.cs
+++ b/Spiderly.Shared/Authorization/SpiderlyPrincipalAccessor.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
@@ -56,11 +55,11 @@ namespace Spiderly.Shared.Authorization
             if (httpContext?.User?.Identity?.IsAuthenticated != true)
                 return null;
 
-            string subject = httpContext.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier)?.Value;
+            string subject = httpContext.User.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             if (long.TryParse(subject, out long userId) == false)
                 return null;
 
-            string kind = httpContext.User.Claims.FirstOrDefault(x => x.Type == PrincipalClaims.PrincipalKind)?.Value;
+            string kind = httpContext.User.FindFirst(PrincipalClaims.PrincipalKind)?.Value;
             return SpiderlyPrincipal.ForUser(userId, kind);
         }
 

--- a/Spiderly.Shared/Exceptions/SpiderlyExceptionHandler.cs
+++ b/Spiderly.Shared/Exceptions/SpiderlyExceptionHandler.cs
@@ -11,6 +11,7 @@ using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Microsoft.IdentityModel.Tokens;
 using Npgsql;
+using Spiderly.Shared.Authorization;
 using Spiderly.Shared.Contracts;
 using Spiderly.Shared.DTO;
 using Spiderly.Shared.Helpers;
@@ -27,19 +28,22 @@ namespace Spiderly.Shared.Exceptions
         private readonly IWebHostEnvironment _env;
         private readonly TokenKeyOptions _tokenKeySettings;
         private readonly CookieManager _cookieManager;
+        private readonly ISpiderlyPrincipalAccessor _principalAccessor;
 
         public SpiderlyExceptionHandler(
             ILogger<SpiderlyExceptionHandler> logger,
             IStringLocalizer localizer,
             IWebHostEnvironment env,
             IOptions<TokenKeyOptions> tokenKeyOptions,
-            CookieManager cookieManager)
+            CookieManager cookieManager,
+            ISpiderlyPrincipalAccessor principalAccessor)
         {
             _logger = logger;
             _localizer = localizer;
             _env = env;
             _tokenKeySettings = tokenKeyOptions.Value;
             _cookieManager = cookieManager;
+            _principalAccessor = principalAccessor;
         }
 
         public async ValueTask<bool> TryHandleAsync(HttpContext httpContext, Exception ex, CancellationToken cancellationToken)
@@ -47,7 +51,7 @@ namespace Spiderly.Shared.Exceptions
             httpContext.Response.ContentType = "application/json";
 
             string exceptionString = _env.IsDevelopment() ? ex.ToString() : null;
-            long? userId = Helper.GetCurrentUserIdOrDefault(httpContext);
+            long? userId = _principalAccessor.Current.UserId;
 
             ApiErrorDTO body;
             LogLevel logLevel;

--- a/Spiderly.Shared/Helpers/Helper.cs
+++ b/Spiderly.Shared/Helpers/Helper.cs
@@ -280,28 +280,6 @@ namespace Spiderly.Shared.Helpers
 
         #region Security
 
-        #region User
-
-        public static bool IsUserLoggedIn(HttpContext context)
-        {
-            return context?.User?.Identity?.IsAuthenticated ?? false;
-        }
-
-        public static long GetCurrentUserId(HttpContext context)
-        {
-            return long.Parse(context.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier).Value);
-        }
-
-        public static long? GetCurrentUserIdOrDefault(HttpContext context)
-        {
-            if (IsUserLoggedIn(context))
-                return long.Parse(context.User.Claims.FirstOrDefault(x => x.Type == ClaimTypes.NameIdentifier).Value);
-
-            return null;
-        }
-
-        #endregion
-
         #region JWT
 
         /// <summary>

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -1854,7 +1854,7 @@ namespace {{appName}}.WebAPI.Controllers
         public async Task<UserDTO> GetCurrentUser()
         {
             long userId = _authenticationService.GetCurrentUserId();
-            return await _userService.GetUserDTO(userId, false); // Don't need to authorize because he is current user
+            return await _userService.GetUserDTO(userId); // Current user reading own profile; admin reads are gated by [HasPermission("ReadUser")] on the generated endpoint
         }
 
     }
@@ -1930,7 +1930,7 @@ namespace {{appName}}.Business.Services
     {
         public OutboxMessageService(EntityServiceDependencies deps) : base(deps) { }
 
-        public override async Task<PaginatedResult<OutboxMessage>> GetPaginatedOutboxMessageList(
+        public override async Task<PaginatedResult<OutboxMessage>> GetPaginatedOutboxMessageResult(
             FilterDTO filterDTO, IQueryable<OutboxMessage> query)
         {
             bool hasExplicitDispatchedFilter = filterDTO.Filters != null
@@ -1939,7 +1939,7 @@ namespace {{appName}}.Business.Services
             if (!hasExplicitDispatchedFilter)
                 query = query.Where(x => x.DispatchedAt == null);
 
-            return await base.GetPaginatedOutboxMessageList(filterDTO, query);
+            return await base.GetPaginatedOutboxMessageResult(filterDTO, query);
         }
     }
 }
@@ -2577,12 +2577,10 @@ namespace {{appName}}.WebAPI
         private static string GetAppServiceExtensionsCsData(string appName)
         {
             return $$"""
-using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
 using Spiderly.Security;
-using Spiderly.Security.Authorization;
 using Spiderly.Security.Extensions;
 using Spiderly.Security.Interfaces;
 using Spiderly.Security.Services;
@@ -2600,13 +2598,12 @@ namespace {{appName}}.WebAPI.Extensions
             #region Spiderly
 
             services.AddTransient<AuthenticationService>();
-            // Forward AuthorizationServiceBase to the app's generated authorization service so framework
-            // consumers (e.g. PermissionAuthorizationHandler) resolve the most-derived IsAuthorizedAsync override.
-            services.AddTransient<AuthorizationServiceBase>(sp => sp.GetRequiredService<{{appName}}.Business.Services.AuthorizationServiceGenerated>());
             services.AddTransient<SecurityServiceBase<User, UserExternalLogin>>();
 
-            // Evaluates [HasPermission] / [Authorize("perm:...")] policies via the permission policy provider.
-            services.AddScoped<IAuthorizationHandler, PermissionAuthorizationHandler>();
+            // Permission-as-policy authorization: registers the [HasPermission] handler and forwards the framework's
+            // AuthorizationServiceBase to this app's generated authorization service (so its IsAuthorizedAsync override
+            // applies). Pairs with PermissionPolicyProvider, which AddSpiderly registers.
+            services.AddSpiderlyAuthorization<{{appName}}.Business.Services.AuthorizationServiceGenerated>();
 
             // Register the application's principal kind(s). A single-principal app registers just User; the
             // kind-dispatched authorization resolves it even without a principal_kind claim (single kind = the
@@ -2928,18 +2925,6 @@ namespace {{appName}}.Business.Services
         }
 
         #region User
-
-        public override async Task AuthorizeUserReadAndThrow(long? userId)
-        {
-            await _context.WithTransactionAsync(async () =>
-            {
-                bool hasAdminReadPermission = await IsAuthorizedAsync<User>(PermissionCodes.ReadUser);
-                bool isCurrentUser = _authenticationService.GetCurrentUserId() == userId;
-
-                if (isCurrentUser == false && hasAdminReadPermission == false)
-                    throw new UnauthorizedException();
-            });
-        }
 
         public override async Task AuthorizeUserUpdateAndThrow(UserDTO userDTO)
         {

--- a/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#MemberService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#MemberService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Member, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Member entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>MemberMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<MemberMainUIFormDTO> GetMemberMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<MemberMainUIFormDTO> GetMemberMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(id);
-                }
-
                 var result = new MemberMainUIFormDTO
                 {
-                    MemberDTO = await GetMemberDTO(id, false),
+                    MemberDTO = await GetMemberDTO(id),
                 };
 
                 await OnAfterGetMemberMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Member entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Member entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>MemberDTO with all blob properties populated</returns>
-        public async virtual Task<MemberDTO> GetMemberDTO(long id, bool authorize)
+        public async virtual Task<MemberDTO> GetMemberDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Member>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<MemberDTO>(Mapper.MemberProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Member>> GetPaginatedMemberList(FilterDTO filterDTO, IQueryable<Member> query)
+        public async virtual Task<PaginatedResult<Member>> GetPaginatedMemberResult(FilterDTO filterDTO, IQueryable<Member> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing MemberDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<MemberDTO>> GetPaginatedMemberList(FilterDTO filterDTO, IQueryable<Member> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<MemberDTO>> GetPaginatedMemberList(FilterDTO filterDTO, IQueryable<Member> query)
         {
             PaginatedResult<Member> paginationResult = new();
             List<MemberDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedMemberList(filterDTO, query);
+                paginationResult = await GetPaginatedMemberResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<MemberDTO>(Mapper.MemberProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportMemberListToExcel(FilterDTO filterDTO, IQueryable<Member> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportMemberListToExcel(FilterDTO filterDTO, IQueryable<Member> query, CancellationToken cancellationToken = default)
         {
             IQueryable<MemberDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Member> paginationResult = await GetPaginatedMemberList(filterDTO, query);
+                PaginatedResult<Member> paginationResult = await GetPaginatedMemberResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Member entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Member entities</returns>
-        public async virtual Task<List<Member>> GetMemberList(IQueryable<Member> query, bool authorize)
+        public async virtual Task<List<Member>> GetMemberList(IQueryable<Member> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Member DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of MemberDTO with blob properties populated</returns>
-        public async virtual Task<List<MemberDTO>> GetMemberDTOList(IQueryable<Member> query, bool authorize)
+        public async virtual Task<List<MemberDTO>> GetMemberDTOList(IQueryable<Member> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<MemberDTO>(Mapper.MemberToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -243,24 +212,15 @@ namespace TestApp.Business.Services
         /// <param name="limit">Maximum number of results to return</param>
         /// <param name="filter">Text filter for Name</param>
         /// <param name="query">Base query for Team entities</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
-        /// <param name="memberId">Optional Member ID for context-specific authorization</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
         public async virtual Task<List<NamebookDTO<long>>> GetTeamAutocompleteListForMember(
             int limit,
             string filter,
-            IQueryable<Team> query,
-            bool authorize,
-            long? memberId = null
+            IQueryable<Team> query
         )
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberReadAndThrow(memberId);
-                }
-
                 if (!string.IsNullOrEmpty(filter))
                     query = query.Where(x => x.Name.ToLower().Contains(filter.ToLower()));
 
@@ -473,8 +433,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Member entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteMember(long id, bool authorize)
+        public async virtual Task DeleteMember(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -485,11 +444,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -510,8 +464,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Member entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteMemberList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteMemberList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -522,11 +475,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeMemberDeleteAndThrow(listForDelete_1);
-                }
 
 
 

--- a/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#OrgService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#OrgService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Org, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Org entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>OrgMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<OrgMainUIFormDTO> GetOrgMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<OrgMainUIFormDTO> GetOrgMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(id);
-                }
-
                 var result = new OrgMainUIFormDTO
                 {
-                    OrgDTO = await GetOrgDTO(id, false),
+                    OrgDTO = await GetOrgDTO(id),
                 };
 
                 await OnAfterGetOrgMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Org entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Org entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>OrgDTO with all blob properties populated</returns>
-        public async virtual Task<OrgDTO> GetOrgDTO(long id, bool authorize)
+        public async virtual Task<OrgDTO> GetOrgDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Org>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<OrgDTO>(Mapper.OrgProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Org>> GetPaginatedOrgList(FilterDTO filterDTO, IQueryable<Org> query)
+        public async virtual Task<PaginatedResult<Org>> GetPaginatedOrgResult(FilterDTO filterDTO, IQueryable<Org> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing OrgDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<OrgDTO>> GetPaginatedOrgList(FilterDTO filterDTO, IQueryable<Org> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<OrgDTO>> GetPaginatedOrgList(FilterDTO filterDTO, IQueryable<Org> query)
         {
             PaginatedResult<Org> paginationResult = new();
             List<OrgDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedOrgList(filterDTO, query);
+                paginationResult = await GetPaginatedOrgResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<OrgDTO>(Mapper.OrgProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportOrgListToExcel(FilterDTO filterDTO, IQueryable<Org> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportOrgListToExcel(FilterDTO filterDTO, IQueryable<Org> query, CancellationToken cancellationToken = default)
         {
             IQueryable<OrgDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Org> paginationResult = await GetPaginatedOrgList(filterDTO, query);
+                PaginatedResult<Org> paginationResult = await GetPaginatedOrgResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Org entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Org entities</returns>
-        public async virtual Task<List<Org>> GetOrgList(IQueryable<Org> query, bool authorize)
+        public async virtual Task<List<Org>> GetOrgList(IQueryable<Org> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Org DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of OrgDTO with blob properties populated</returns>
-        public async virtual Task<List<OrgDTO>> GetOrgDTOList(IQueryable<Org> query, bool authorize)
+        public async virtual Task<List<OrgDTO>> GetOrgDTOList(IQueryable<Org> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<OrgDTO>(Mapper.OrgToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -425,8 +394,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Org entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteOrg(long id, bool authorize)
+        public async virtual Task DeleteOrg(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -437,11 +405,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -480,8 +443,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Org entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteOrgList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteOrgList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -492,11 +454,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgDeleteAndThrow(listForDelete_1);
-                }
 
                 var teamListForDeleteBecauseOrg_2 = await _deps.Context.DbSet<Team>()
                     .AsNoTracking()
@@ -530,17 +487,11 @@ namespace TestApp.Business.Services
         /// Retrieves namebook DTOs for Team entities related to a Org.
         /// </summary>
         /// <param name="id">The ID of the Org entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
-        public async virtual Task<List<NamebookDTO<long>>> GetTeamsNamebookListForOrg(long id, bool authorize)
+        public async virtual Task<List<NamebookDTO<long>>> GetTeamsNamebookListForOrg(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeOrgReadAndThrow(id);
-                }
-
                 return await _deps.Context.DbSet<Team>()
                     .AsNoTracking()
                     .Where(x => EF.Property<long>(x, "OrgId") == id)

--- a/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#TeamService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/CascadeDeleteWalkerTests.MultiLevelCascade_OrdersGrandchildBeforeChild#TeamService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Team, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Team entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TeamMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<TeamMainUIFormDTO> GetTeamMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<TeamMainUIFormDTO> GetTeamMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(id);
-                }
-
                 var result = new TeamMainUIFormDTO
                 {
-                    TeamDTO = await GetTeamDTO(id, false),
+                    TeamDTO = await GetTeamDTO(id),
                 };
 
                 await OnAfterGetTeamMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Team entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Team entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TeamDTO with all blob properties populated</returns>
-        public async virtual Task<TeamDTO> GetTeamDTO(long id, bool authorize)
+        public async virtual Task<TeamDTO> GetTeamDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Team>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<TeamDTO>(Mapper.TeamProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Team>> GetPaginatedTeamList(FilterDTO filterDTO, IQueryable<Team> query)
+        public async virtual Task<PaginatedResult<Team>> GetPaginatedTeamResult(FilterDTO filterDTO, IQueryable<Team> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing TeamDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<TeamDTO>> GetPaginatedTeamList(FilterDTO filterDTO, IQueryable<Team> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<TeamDTO>> GetPaginatedTeamList(FilterDTO filterDTO, IQueryable<Team> query)
         {
             PaginatedResult<Team> paginationResult = new();
             List<TeamDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedTeamList(filterDTO, query);
+                paginationResult = await GetPaginatedTeamResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<TeamDTO>(Mapper.TeamProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportTeamListToExcel(FilterDTO filterDTO, IQueryable<Team> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportTeamListToExcel(FilterDTO filterDTO, IQueryable<Team> query, CancellationToken cancellationToken = default)
         {
             IQueryable<TeamDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Team> paginationResult = await GetPaginatedTeamList(filterDTO, query);
+                PaginatedResult<Team> paginationResult = await GetPaginatedTeamResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Team entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Team entities</returns>
-        public async virtual Task<List<Team>> GetTeamList(IQueryable<Team> query, bool authorize)
+        public async virtual Task<List<Team>> GetTeamList(IQueryable<Team> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Team DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of TeamDTO with blob properties populated</returns>
-        public async virtual Task<List<TeamDTO>> GetTeamDTOList(IQueryable<Team> query, bool authorize)
+        public async virtual Task<List<TeamDTO>> GetTeamDTOList(IQueryable<Team> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<TeamDTO>(Mapper.TeamToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -243,24 +212,15 @@ namespace TestApp.Business.Services
         /// <param name="limit">Maximum number of results to return</param>
         /// <param name="filter">Text filter for Name</param>
         /// <param name="query">Base query for Org entities</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
-        /// <param name="teamId">Optional Team ID for context-specific authorization</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
         public async virtual Task<List<NamebookDTO<long>>> GetOrgAutocompleteListForTeam(
             int limit,
             string filter,
-            IQueryable<Org> query,
-            bool authorize,
-            long? teamId = null
+            IQueryable<Org> query
         )
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(teamId);
-                }
-
                 if (!string.IsNullOrEmpty(filter))
                     query = query.Where(x => x.Name.ToLower().Contains(filter.ToLower()));
 
@@ -473,8 +433,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Team entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTeam(long id, bool authorize)
+        public async virtual Task DeleteTeam(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -485,11 +444,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -518,8 +472,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Team entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTeamList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteTeamList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -530,11 +483,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamDeleteAndThrow(listForDelete_1);
-                }
 
                 var memberListForDeleteBecauseTeam_2 = await _deps.Context.DbSet<Member>()
                     .AsNoTracking()
@@ -558,17 +506,11 @@ namespace TestApp.Business.Services
         /// Retrieves namebook DTOs for Member entities related to a Team.
         /// </summary>
         /// <param name="id">The ID of the Team entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
-        public async virtual Task<List<NamebookDTO<long>>> GetMembersNamebookListForTeam(long id, bool authorize)
+        public async virtual Task<List<NamebookDTO<long>>> GetMembersNamebookListForTeam(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTeamReadAndThrow(id);
-                }
-
                 return await _deps.Context.DbSet<Member>()
                     .AsNoTracking()
                     .Where(x => EF.Property<long>(x, "TeamId") == id)

--- a/Spiderly.SourceGenerators.Tests/Generators/ControllerPermissionAttributeTests.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/ControllerPermissionAttributeTests.cs
@@ -1,3 +1,4 @@
+using Spiderly.SourceGenerators.Enums;
 using Spiderly.SourceGenerators.Models;
 using Spiderly.SourceGenerators.Shared;
 
@@ -18,8 +19,8 @@ public class ControllerPermissionAttributeTests
     {
         SpiderlyClass entity = new() { Name = "Product" };
 
-        Assert.Equal("[HasPermission(\"ReadProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, "Read"));
-        Assert.Equal("[HasPermission(\"DeleteProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, "Delete"));
+        Assert.Equal("[HasPermission(\"ReadProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, CrudCodes.Read));
+        Assert.Equal("[HasPermission(\"DeleteProduct\")]\n        ", Helpers.GetPermissionAttribute(entity, CrudCodes.Delete));
     }
 
     [Fact]
@@ -31,7 +32,7 @@ public class ControllerPermissionAttributeTests
             Attributes = new() { new SpiderlyAttribute { Name = "DoNotAuthorize" } },
         };
 
-        Assert.Equal("", Helpers.GetPermissionAttribute(entity, "Read"));
-        Assert.Equal("", Helpers.GetPermissionAttribute(entity, "Delete"));
+        Assert.Equal("", Helpers.GetPermissionAttribute(entity, CrudCodes.Read));
+        Assert.Equal("", Helpers.GetPermissionAttribute(entity, CrudCodes.Delete));
     }
 }

--- a/Spiderly.SourceGenerators.Tests/Generators/OneToOneCascadeTests.CascadeDelete_OnWithOneNav_DeletesDependentBeforePrincipal#ConversationService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/OneToOneCascadeTests.CascadeDelete_OnWithOneNav_DeletesDependentBeforePrincipal#ConversationService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Conversation, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Conversation entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>ConversationMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<ConversationMainUIFormDTO> GetConversationMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<ConversationMainUIFormDTO> GetConversationMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(id);
-                }
-
                 var result = new ConversationMainUIFormDTO
                 {
-                    ConversationDTO = await GetConversationDTO(id, false),
+                    ConversationDTO = await GetConversationDTO(id),
                 };
 
                 await OnAfterGetConversationMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Conversation entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Conversation entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>ConversationDTO with all blob properties populated</returns>
-        public async virtual Task<ConversationDTO> GetConversationDTO(long id, bool authorize)
+        public async virtual Task<ConversationDTO> GetConversationDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Conversation>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<ConversationDTO>(Mapper.ConversationProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Conversation>> GetPaginatedConversationList(FilterDTO filterDTO, IQueryable<Conversation> query)
+        public async virtual Task<PaginatedResult<Conversation>> GetPaginatedConversationResult(FilterDTO filterDTO, IQueryable<Conversation> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing ConversationDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<ConversationDTO>> GetPaginatedConversationList(FilterDTO filterDTO, IQueryable<Conversation> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<ConversationDTO>> GetPaginatedConversationList(FilterDTO filterDTO, IQueryable<Conversation> query)
         {
             PaginatedResult<Conversation> paginationResult = new();
             List<ConversationDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedConversationList(filterDTO, query);
+                paginationResult = await GetPaginatedConversationResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<ConversationDTO>(Mapper.ConversationProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportConversationListToExcel(FilterDTO filterDTO, IQueryable<Conversation> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportConversationListToExcel(FilterDTO filterDTO, IQueryable<Conversation> query, CancellationToken cancellationToken = default)
         {
             IQueryable<ConversationDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Conversation> paginationResult = await GetPaginatedConversationList(filterDTO, query);
+                PaginatedResult<Conversation> paginationResult = await GetPaginatedConversationResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Conversation entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Conversation entities</returns>
-        public async virtual Task<List<Conversation>> GetConversationList(IQueryable<Conversation> query, bool authorize)
+        public async virtual Task<List<Conversation>> GetConversationList(IQueryable<Conversation> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Conversation DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of ConversationDTO with blob properties populated</returns>
-        public async virtual Task<List<ConversationDTO>> GetConversationDTOList(IQueryable<Conversation> query, bool authorize)
+        public async virtual Task<List<ConversationDTO>> GetConversationDTOList(IQueryable<Conversation> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<ConversationDTO>(Mapper.ConversationToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -243,24 +212,15 @@ namespace TestApp.Business.Services
         /// <param name="limit">Maximum number of results to return</param>
         /// <param name="filter">Text filter for Title</param>
         /// <param name="query">Base query for TaskItem entities</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
-        /// <param name="conversationId">Optional Conversation ID for context-specific authorization</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
         public async virtual Task<List<NamebookDTO<long>>> GetOwningTaskItemAutocompleteListForConversation(
             int limit,
             string filter,
-            IQueryable<TaskItem> query,
-            bool authorize,
-            long? conversationId = null
+            IQueryable<TaskItem> query
         )
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationReadAndThrow(conversationId);
-                }
-
                 if (!string.IsNullOrEmpty(filter))
                     query = query.Where(x => x.Title.ToLower().Contains(filter.ToLower()));
 
@@ -473,8 +433,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Conversation entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteConversation(long id, bool authorize)
+        public async virtual Task DeleteConversation(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -485,11 +444,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -510,8 +464,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Conversation entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteConversationList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteConversationList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -522,11 +475,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeConversationDeleteAndThrow(listForDelete_1);
-                }
 
 
 

--- a/Spiderly.SourceGenerators.Tests/Generators/OneToOneCascadeTests.CascadeDelete_OnWithOneNav_DeletesDependentBeforePrincipal#TaskItemService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/OneToOneCascadeTests.CascadeDelete_OnWithOneNav_DeletesDependentBeforePrincipal#TaskItemService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for TaskItem, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the TaskItem entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TaskItemMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<TaskItemMainUIFormDTO> GetTaskItemMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<TaskItemMainUIFormDTO> GetTaskItemMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemReadAndThrow(id);
-                }
-
                 var result = new TaskItemMainUIFormDTO
                 {
-                    TaskItemDTO = await GetTaskItemDTO(id, false),
+                    TaskItemDTO = await GetTaskItemDTO(id),
                 };
 
                 await OnAfterGetTaskItemMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single TaskItem entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the TaskItem entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TaskItemDTO with all blob properties populated</returns>
-        public async virtual Task<TaskItemDTO> GetTaskItemDTO(long id, bool authorize)
+        public async virtual Task<TaskItemDTO> GetTaskItemDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<TaskItem>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<TaskItemDTO>(Mapper.TaskItemProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<TaskItem>> GetPaginatedTaskItemList(FilterDTO filterDTO, IQueryable<TaskItem> query)
+        public async virtual Task<PaginatedResult<TaskItem>> GetPaginatedTaskItemResult(FilterDTO filterDTO, IQueryable<TaskItem> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing TaskItemDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<TaskItemDTO>> GetPaginatedTaskItemList(FilterDTO filterDTO, IQueryable<TaskItem> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<TaskItemDTO>> GetPaginatedTaskItemList(FilterDTO filterDTO, IQueryable<TaskItem> query)
         {
             PaginatedResult<TaskItem> paginationResult = new();
             List<TaskItemDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedTaskItemList(filterDTO, query);
+                paginationResult = await GetPaginatedTaskItemResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<TaskItemDTO>(Mapper.TaskItemProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportTaskItemListToExcel(FilterDTO filterDTO, IQueryable<TaskItem> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportTaskItemListToExcel(FilterDTO filterDTO, IQueryable<TaskItem> query, CancellationToken cancellationToken = default)
         {
             IQueryable<TaskItemDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<TaskItem> paginationResult = await GetPaginatedTaskItemList(filterDTO, query);
+                PaginatedResult<TaskItem> paginationResult = await GetPaginatedTaskItemResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of TaskItem entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of TaskItem entities</returns>
-        public async virtual Task<List<TaskItem>> GetTaskItemList(IQueryable<TaskItem> query, bool authorize)
+        public async virtual Task<List<TaskItem>> GetTaskItemList(IQueryable<TaskItem> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of TaskItem DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of TaskItemDTO with blob properties populated</returns>
-        public async virtual Task<List<TaskItemDTO>> GetTaskItemDTOList(IQueryable<TaskItem> query, bool authorize)
+        public async virtual Task<List<TaskItemDTO>> GetTaskItemDTOList(IQueryable<TaskItem> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<TaskItemDTO>(Mapper.TaskItemToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -425,8 +394,7 @@ namespace TestApp.Business.Services
         /// Deletes a single TaskItem entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTaskItem(long id, bool authorize)
+        public async virtual Task DeleteTaskItem(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -437,11 +405,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -470,8 +433,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple TaskItem entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTaskItemList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteTaskItemList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -482,11 +444,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTaskItemDeleteAndThrow(listForDelete_1);
-                }
 
                 var conversationListForDeleteBecauseOwningTaskItem_2 = await _deps.Context.DbSet<Conversation>()
                     .AsNoTracking()

--- a/Spiderly.SourceGenerators.Tests/Generators/ServicesGeneratorTests.EntityWithOneToManyAndCustomService_EmitsServiceClass#ProductService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/ServicesGeneratorTests.EntityWithOneToManyAndCustomService_EmitsServiceClass#ProductService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Product, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Product entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>ProductMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<ProductMainUIFormDTO> GetProductMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<ProductMainUIFormDTO> GetProductMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductReadAndThrow(id);
-                }
-
                 var result = new ProductMainUIFormDTO
                 {
-                    ProductDTO = await GetProductDTO(id, false),
+                    ProductDTO = await GetProductDTO(id),
                 };
 
                 await OnAfterGetProductMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Product entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Product entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>ProductDTO with all blob properties populated</returns>
-        public async virtual Task<ProductDTO> GetProductDTO(long id, bool authorize)
+        public async virtual Task<ProductDTO> GetProductDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Product>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<ProductDTO>(Mapper.ProductProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Product>> GetPaginatedProductList(FilterDTO filterDTO, IQueryable<Product> query)
+        public async virtual Task<PaginatedResult<Product>> GetPaginatedProductResult(FilterDTO filterDTO, IQueryable<Product> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing ProductDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<ProductDTO>> GetPaginatedProductList(FilterDTO filterDTO, IQueryable<Product> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<ProductDTO>> GetPaginatedProductList(FilterDTO filterDTO, IQueryable<Product> query)
         {
             PaginatedResult<Product> paginationResult = new();
             List<ProductDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedProductList(filterDTO, query);
+                paginationResult = await GetPaginatedProductResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<ProductDTO>(Mapper.ProductProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportProductListToExcel(FilterDTO filterDTO, IQueryable<Product> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportProductListToExcel(FilterDTO filterDTO, IQueryable<Product> query, CancellationToken cancellationToken = default)
         {
             IQueryable<ProductDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Product> paginationResult = await GetPaginatedProductList(filterDTO, query);
+                PaginatedResult<Product> paginationResult = await GetPaginatedProductResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Product entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Product entities</returns>
-        public async virtual Task<List<Product>> GetProductList(IQueryable<Product> query, bool authorize)
+        public async virtual Task<List<Product>> GetProductList(IQueryable<Product> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Product DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of ProductDTO with blob properties populated</returns>
-        public async virtual Task<List<ProductDTO>> GetProductDTOList(IQueryable<Product> query, bool authorize)
+        public async virtual Task<List<ProductDTO>> GetProductDTOList(IQueryable<Product> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<ProductDTO>(Mapper.ProductToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -425,8 +394,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Product entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteProduct(long id, bool authorize)
+        public async virtual Task DeleteProduct(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -437,11 +405,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -462,8 +425,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Product entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteProductList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteProductList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -474,11 +436,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeProductDeleteAndThrow(listForDelete_1);
-                }
 
 
 

--- a/Spiderly.SourceGenerators.Tests/Generators/ServicesGeneratorTests.EntityWithOneToManyAndCustomService_EmitsServiceClass#TagService.generated.verified.cs
+++ b/Spiderly.SourceGenerators.Tests/Generators/ServicesGeneratorTests.EntityWithOneToManyAndCustomService_EmitsServiceClass#TagService.generated.verified.cs
@@ -47,20 +47,14 @@ namespace TestApp.Business.Services
         /// Retrieves the complete MainUIFormDTO for Tag, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the Tag entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TagMainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<TagMainUIFormDTO> GetTagMainUIFormDTO(long id, bool authorize)
+        public async virtual Task<TagMainUIFormDTO> GetTagMainUIFormDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagReadAndThrow(id);
-                }
-
                 var result = new TagMainUIFormDTO
                 {
-                    TagDTO = await GetTagDTO(id, false),
+                    TagDTO = await GetTagDTO(id),
                 };
 
                 await OnAfterGetTagMainUIFormDTO(result);
@@ -87,17 +81,11 @@ namespace TestApp.Business.Services
         /// Retrieves a single Tag entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the Tag entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>TagDTO with all blob properties populated</returns>
-        public async virtual Task<TagDTO> GetTagDTO(long id, bool authorize)
+        public async virtual Task<TagDTO> GetTagDTO(long id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagReadAndThrow(id);
-                }
-
                 var dto = await _deps.Context.DbSet<Tag>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<TagDTO>(Mapper.TagProjectToConfig())
@@ -118,7 +106,7 @@ namespace TestApp.Business.Services
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<Tag>> GetPaginatedTagList(FilterDTO filterDTO, IQueryable<Tag> query)
+        public async virtual Task<PaginatedResult<Tag>> GetPaginatedTagResult(FilterDTO filterDTO, IQueryable<Tag> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -131,27 +119,21 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing TagDTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<TagDTO>> GetPaginatedTagList(FilterDTO filterDTO, IQueryable<Tag> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<TagDTO>> GetPaginatedTagList(FilterDTO filterDTO, IQueryable<Tag> query)
         {
             PaginatedResult<Tag> paginationResult = new();
             List<TagDTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginatedTagList(filterDTO, query);
+                paginationResult = await GetPaginatedTagResult(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<TagDTO>(Mapper.TagProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
             });
@@ -164,16 +146,15 @@ namespace TestApp.Business.Services
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> ExportTagListToExcel(FilterDTO filterDTO, IQueryable<Tag> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> ExportTagListToExcel(FilterDTO filterDTO, IQueryable<Tag> query, CancellationToken cancellationToken = default)
         {
             IQueryable<TagDTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<Tag> paginationResult = await GetPaginatedTagList(filterDTO, query);
+                PaginatedResult<Tag> paginationResult = await GetPaginatedTagResult(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -193,19 +174,13 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Tag entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of Tag entities</returns>
-        public async virtual Task<List<Tag>> GetTagList(IQueryable<Tag> query, bool authorize)
+        public async virtual Task<List<Tag>> GetTagList(IQueryable<Tag> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagReadAndThrow(result.Select(x => x.Id).ToList());
-                }
 
                 return result;
             });
@@ -215,9 +190,8 @@ namespace TestApp.Business.Services
         /// Retrieves a list of Tag DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of TagDTO with blob properties populated</returns>
-        public async virtual Task<List<TagDTO>> GetTagDTOList(IQueryable<Tag> query, bool authorize)
+        public async virtual Task<List<TagDTO>> GetTagDTOList(IQueryable<Tag> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -225,11 +199,6 @@ namespace TestApp.Business.Services
                     .AsNoTracking()
                     .ProjectToType<TagDTO>(Mapper.TagToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagReadAndThrow(dtoList.Select(x => x.Id).ToList());
-                }
 
 
 
@@ -425,8 +394,7 @@ namespace TestApp.Business.Services
         /// Deletes a single Tag entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTag(long id, bool authorize)
+        public async virtual Task DeleteTag(long id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -437,11 +405,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagDeleteAndThrow(id);
-                }
 
                 List<long> listForDelete_1 = id.StructToList();
 
@@ -462,8 +425,7 @@ namespace TestApp.Business.Services
         /// Deletes multiple Tag entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_1">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task DeleteTagList(List<long> listForDelete_1, bool authorize)
+        public async virtual Task DeleteTagList(List<long> listForDelete_1)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -474,11 +436,6 @@ namespace TestApp.Business.Services
                 // won't flush them and WithTransactionAsync's clean-tracker guard would throw.
                 if (_deps.Context.ChangeTracker.HasChanges())
                     await _deps.Context.SaveChangesAsync();
-
-                if (authorize)
-                {
-                    await _deps.AuthorizationService.AuthorizeTagDeleteAndThrow(listForDelete_1);
-                }
 
 
 

--- a/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsDataGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsDataGenerator.cs
@@ -72,7 +72,7 @@ namespace Spiderly.SourceGenerators.Angular
             return result;
         }
 
-        internal static List<string> GetManyToManyMultiSelectListForDropdownMethods(SpiderlyClass entity, List<SpiderlyClass> entities, bool isFromOrderedOneToMany = false)
+        internal static List<string> GetManyToManyMultiSelectListForDropdownMethods(SpiderlyClass entity, List<SpiderlyClass> entities)
         {
             List<string> result = new();
 
@@ -82,7 +82,7 @@ namespace Spiderly.SourceGenerators.Angular
                 {
                     SpiderlyClass extractedEntity = Helpers.GetEntityByPropertyType(property, entities);
 
-                    result.AddRange(GetManyToManyMultiSelectListForDropdownMethods(extractedEntity, entities, isFromOrderedOneToMany: true));
+                    result.AddRange(GetManyToManyMultiSelectListForDropdownMethods(extractedEntity, entities));
 
                     continue;
                 }
@@ -90,10 +90,8 @@ namespace Spiderly.SourceGenerators.Angular
                 if (property.IsMultiSelectControlType() == false && property.IsDropdownControlType() == false)
                     continue;
 
-                string idArgument = isFromOrderedOneToMany ? "null" : "this.modelId";
-
                 result.Add($$"""
-            this.apiService.get{{property.Name}}DropdownListFor{{entity.Name}}({{idArgument}}).subscribe(no => {
+            this.apiService.get{{property.Name}}DropdownListFor{{entity.Name}}().subscribe(no => {
                 this.{{property.Name.FirstCharToLower()}}OptionsFor{{entity.Name}} = no;
             });
 """);
@@ -141,8 +139,8 @@ namespace Spiderly.SourceGenerators.Angular
                     controlType == UIControlTypeCodes.MultiAutocomplete)
                 {
                     result.Add($$"""
-    search{{context.Property.Name}}For{{context.Entity.Name}}(event: AutoCompleteCompleteEvent, modelId: number = null) {
-        this.apiService.get{{context.Property.Name}}AutocompleteListFor{{context.Entity.Name}}(50, event?.query ?? '', modelId).subscribe(no => {
+    search{{context.Property.Name}}For{{context.Entity.Name}}(event: AutoCompleteCompleteEvent) {
+        this.apiService.get{{context.Property.Name}}AutocompleteListFor{{context.Entity.Name}}(50, event?.query ?? '').subscribe(no => {
             this.{{context.Property.Name.FirstCharToLower()}}OptionsFor{{context.Entity.Name}} = no;
         });
     }

--- a/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsPropertyBlockGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/BaseDetails/NgDetailsPropertyBlockGenerator.cs
@@ -539,7 +539,7 @@ namespace Spiderly.SourceGenerators.Angular
             }
             else if (controlType == UIControlTypeCodes.Autocomplete)
             {
-                return $"[control]=\"{GetControlHtmlAttributeValue(property, entity, isFromOrderedOneToMany)}\" [options]=\"{property.Name.FirstCharToLower()}OptionsFor{entity.Name}\" [displayName]=\"{GetMainDTOFormGroupForMainUIForm(entity, isFromOrderedOneToMany)}.controls.{property.Name.FirstCharToLower()}DisplayName.getRawValue()\" (onTextInput)=\"search{property.Name}For{entity.Name}($event, {GetMainDTOFormGroupForMainUIForm(entity, isFromOrderedOneToMany)}.controls.id.getRawValue())\" ";
+                return $"[control]=\"{GetControlHtmlAttributeValue(property, entity, isFromOrderedOneToMany)}\" [options]=\"{property.Name.FirstCharToLower()}OptionsFor{entity.Name}\" [displayName]=\"{GetMainDTOFormGroupForMainUIForm(entity, isFromOrderedOneToMany)}.controls.{property.Name.FirstCharToLower()}DisplayName.getRawValue()\" (onTextInput)=\"search{property.Name}For{entity.Name}($event)\" ";
             }
             else if (controlType == UIControlTypeCodes.MultiSelect)
             {
@@ -547,7 +547,7 @@ namespace Spiderly.SourceGenerators.Angular
             }
             else if (controlType == UIControlTypeCodes.MultiAutocomplete)
             {
-                return $"[control]=\"{GetControlHtmlAttributeValue(property, entity, isFromOrderedOneToMany, isControlDirectlyOnParent: true)}\" [options]=\"{property.Name.FirstCharToLower()}OptionsFor{entity.Name}\" (onTextInput)=\"search{property.Name}For{entity.Name}($event, {GetMainDTOFormGroupForMainUIForm(entity, isFromOrderedOneToMany)}.controls.id.getRawValue())\" [label]=\"t('{property.Name}')\" ";
+                return $"[control]=\"{GetControlHtmlAttributeValue(property, entity, isFromOrderedOneToMany, isControlDirectlyOnParent: true)}\" [options]=\"{property.Name.FirstCharToLower()}OptionsFor{entity.Name}\" (onTextInput)=\"search{property.Name}For{entity.Name}($event)\" [label]=\"t('{property.Name}')\" ";
             }
             else if (property.HasSimpleManyToManyTableLazyLoadAttribute())
             {

--- a/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
+++ b/Spiderly.SourceGenerators/Angular/NgControllersGenerator.cs
@@ -708,7 +708,6 @@ import { {{ngType}} } from '../../entities/entities.generated';
                     {
                         { "limit", "number" },
                         { "filter", "string" },
-                        { $"{entity.Name.FirstCharToLower()}Id", "number = null"}
                     };
 
                     sb.AppendLine(GetAngularControllerMethod(methodName, getAndDeleteParameters, "Namebook[]", HttpTypeCodes.Get, entity.ControllerName, Settings.HttpOptionsSkipSpinner));
@@ -731,7 +730,7 @@ import { {{ngType}} } from '../../entities/entities.generated';
                     if (alreadyAddedMethods.Contains(methodName))
                         continue;
 
-                    Dictionary<string, string> getAndDeleteParameters = new() { { $"{entity.Name.FirstCharToLower()}Id", "number = null" } };
+                    Dictionary<string, string> getAndDeleteParameters = new();
 
                     sb.AppendLine(GetAngularControllerMethod(methodName, getAndDeleteParameters, "Namebook[]", HttpTypeCodes.Get, entity.ControllerName, Settings.HttpOptionsSkipSpinner));
                 }

--- a/Spiderly.SourceGenerators/Net/AuthorizationServicesGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/AuthorizationServicesGenerator.cs
@@ -98,17 +98,9 @@ namespace {{basePartOfNamespace}}.Services
                 sb.AppendLine($$"""
         #region {{entity.Name}}
 
-{{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Read, $"{entityIdType}? {entity.Name.FirstCharToLower()}IdToRead")}}
-
-{{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Read, $"List<{entityIdType}> {entity.Name.FirstCharToLower()}IdListToRead")}}
-
 {{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Update, $"{entity.Name}DTO dto")}}
 
 {{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Insert, $"{entity.Name}DTO dto")}}
-
-{{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Delete, $"{entityIdType} {entity.Name.FirstCharToLower()}Id")}}
-
-{{GetAuthorizeEntityMethod(entity.Name, entity, CrudCodes.Delete, $"List<{entityIdType}> {entity.Name.FirstCharToLower()}ListToDelete")}}
 
 {{GetBloblAuthorizeEntityMethods(entity, entityIdType)}}
 

--- a/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/ControllerGenerator.cs
@@ -170,7 +170,7 @@ namespace {{basePartOfNamespace}}.Controllers
                 {
                     string referencedProjectEntityClassIdType = controllerEntity.GetIdType(allEntities);
                     string entityServiceField = $"_serviceProvider.GetRequiredService<{controllerEntity.Name}ServiceGenerated>()";
-                    string readPermissionAttribute = Helpers.GetPermissionAttribute(controllerEntity, "Read");
+                    string readPermissionAttribute = Helpers.GetPermissionAttribute(controllerEntity, CrudCodes.Read);
 
                     entityRegion = $$"""
         #region {{controllerEntity.Name}}
@@ -184,7 +184,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{readPermissionAttribute}}public virtual async Task<PaginatedResultDTO<{{controllerEntity.Name}}DTO>> GetPaginated{{controllerEntity.Name}}List(FilterDTO filterDTO)
         {
-            return await {{entityServiceField}}.GetPaginated{{controllerEntity.Name}}List(filterDTO, _context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
+            return await {{entityServiceField}}.GetPaginated{{controllerEntity.Name}}List(filterDTO, _context.DbSet<{{controllerEntity.Name}}>());
         }
 
         /// <summary>
@@ -194,7 +194,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{readPermissionAttribute}}public virtual async Task<IActionResult> Export{{controllerEntity.Name}}ListToExcel(FilterDTO filterDTO)
         {
-            byte[] fileContent = await {{entityServiceField}}.Export{{controllerEntity.Name}}ListToExcel(filterDTO, _context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
+            byte[] fileContent = await {{entityServiceField}}.Export{{controllerEntity.Name}}ListToExcel(filterDTO, _context.DbSet<{{controllerEntity.Name}}>());
             return File(
                 fileContent,
                 _serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Spiderly.Shared.ExcelOptions>>().Value.ExcelContentType,
@@ -209,7 +209,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{readPermissionAttribute}}public virtual async Task<List<{{controllerEntity.Name}}DTO>> Get{{controllerEntity.Name}}List()
         {
-            return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTOList(_context.DbSet<{{controllerEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
+            return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTOList(_context.DbSet<{{controllerEntity.Name}}>());
         }
 
         /// <summary>
@@ -219,7 +219,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{readPermissionAttribute}}public virtual async Task<{{controllerEntity.Name}}MainUIFormDTO> Get{{controllerEntity.Name}}MainUIFormDTO({{referencedProjectEntityClassIdType}} id)
         {
-            return await {{entityServiceField}}.Get{{controllerEntity.Name}}MainUIFormDTO(id, {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
+            return await {{entityServiceField}}.Get{{controllerEntity.Name}}MainUIFormDTO(id);
         }
 
         /// <summary>
@@ -229,7 +229,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{readPermissionAttribute}}public virtual async Task<{{controllerEntity.Name}}DTO> Get{{controllerEntity.Name}}({{referencedProjectEntityClassIdType}} id)
         {
-            return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTO(id, {{Helpers.GetShouldAuthorizeEntityString(controllerEntity)}});
+            return await {{entityServiceField}}.Get{{controllerEntity.Name}}DTO(id);
         }
 
 {{GetManyToOneReadMethods(controllerEntity, allEntities)}}
@@ -322,14 +322,12 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<List<NamebookDTO<{{manyToOneEntityIdType}}>>> Get{{property.Name}}AutocompleteListFor{{entity.Name}}(int limit, string filter, {{entity.GetIdType(allEntities)}}? {{entity.Name.FirstCharToLower()}}Id)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<List<NamebookDTO<{{manyToOneEntityIdType}}>>> Get{{property.Name}}AutocompleteListFor{{entity.Name}}(int limit, string filter)
         {
             return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Get{{property.Name}}AutocompleteListFor{{entity.Name}}(
                 limit,
                 filter,
-                _context.DbSet<{{manyToOneEntity.Name}}>(),
-                {{Helpers.GetShouldAuthorizeEntityString(entity)}},
-                {{entity.Name.FirstCharToLower()}}Id
+                _context.DbSet<{{manyToOneEntity.Name}}>()
             );
         }
 """;
@@ -356,12 +354,10 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<List<NamebookDTO<{{manyToOneEntityIdType}}>>> Get{{property.Name}}DropdownListFor{{entity.Name}}({{entity.GetIdType(allEntities)}}? {{entity.Name.FirstCharToLower()}}Id)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<List<NamebookDTO<{{manyToOneEntityIdType}}>>> Get{{property.Name}}DropdownListFor{{entity.Name}}()
         {
             return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Get{{property.Name}}DropdownListFor{{entity.Name}}(
-                _context.DbSet<{{manyToOneEntity.Name}}>(),
-                {{Helpers.GetShouldAuthorizeEntityString(entity)}},
-                {{entity.Name.FirstCharToLower()}}Id
+                _context.DbSet<{{manyToOneEntity.Name}}>()
             );
         }
 """;
@@ -408,7 +404,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         public virtual async Task<PaginatedResultDTO<{{extractedEntity.Name}}DTO>> GetPaginated{{property.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO)
         {
-            return await _serviceProvider.GetRequiredService<{{extractedEntity.Name}}ServiceGenerated>().GetPaginated{{extractedEntity.Name}}List(filterDTO, _context.DbSet<{{extractedEntity.Name}}>().OrderBy(x => x.Id), false);
+            return await _serviceProvider.GetRequiredService<{{extractedEntity.Name}}ServiceGenerated>().GetPaginated{{extractedEntity.Name}}List(filterDTO, _context.DbSet<{{extractedEntity.Name}}>().OrderBy(x => x.Id));
         }
 
         /// <summary>
@@ -418,7 +414,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         public virtual async Task<IActionResult> Export{{property.Name}}ListToExcelFor{{entity.Name}}(FilterDTO filterDTO)
         {
-            byte[] fileContent = await _serviceProvider.GetRequiredService<{{extractedEntity.Name}}ServiceGenerated>().Export{{extractedEntity.Name}}ListToExcel(filterDTO, _context.DbSet<{{extractedEntity.Name}}>(), false);
+            byte[] fileContent = await _serviceProvider.GetRequiredService<{{extractedEntity.Name}}ServiceGenerated>().Export{{extractedEntity.Name}}ListToExcel(filterDTO, _context.DbSet<{{extractedEntity.Name}}>());
             return File(
                 fileContent,
                 _serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Spiderly.Shared.ExcelOptions>>().Value.ExcelContentType,
@@ -431,9 +427,9 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task<LazyLoadSelectedIdsResultDTO<{{extractedEntityIdType}}>> LazyLoadSelected{{property.Name}}IdsFor{{entity.Name}}(FilterDTO filterDTO)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<LazyLoadSelectedIdsResultDTO<{{extractedEntityIdType}}>> LazyLoadSelected{{property.Name}}IdsFor{{entity.Name}}(FilterDTO filterDTO)
         {
-            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().LazyLoadSelected{{property.Name}}IdsFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>().OrderBy(x => x.Id), {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().LazyLoadSelected{{property.Name}}IdsFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>().OrderBy(x => x.Id));
         }
 """;
         }
@@ -448,9 +444,9 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task<PaginatedResultDTO<{{extractedEntity.Name}}DTO>> GetPaginated{{property.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<PaginatedResultDTO<{{extractedEntity.Name}}DTO>> GetPaginated{{property.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO)
         {
-            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().GetPaginated{{property.Name}}ListFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().GetPaginated{{property.Name}}ListFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>());
         }
 
         /// <summary>
@@ -458,9 +454,9 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpPost]
         [AuthGuard]
-        public virtual async Task<IActionResult> Export{{property.Name}}ListToExcelFor{{entity.Name}}(FilterDTO filterDTO)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<IActionResult> Export{{property.Name}}ListToExcelFor{{entity.Name}}(FilterDTO filterDTO)
         {
-            byte[] fileContent = await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Export{{property.Name}}ListToExcelFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>(), {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            byte[] fileContent = await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Export{{property.Name}}ListToExcelFor{{entity.Name}}(filterDTO, _context.DbSet<{{extractedEntity.Name}}>());
             return File(
                 fileContent,
                 _serviceProvider.GetRequiredService<Microsoft.Extensions.Options.IOptions<Spiderly.Shared.ExcelOptions>>().Value.ExcelContentType,
@@ -482,7 +478,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         public virtual async Task<List<NamebookDTO<{{extractedEntity.GetIdType(entities)}}>>> Get{{property.Name}}NamebookListFor{{entity.Name}}({{entity.GetIdType(entities)}} id)
         {
-            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Get{{property.Name}}NamebookListFor{{entity.Name}}(id, false);
+            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Get{{property.Name}}NamebookListFor{{entity.Name}}(id);
         }
 """;
         }
@@ -505,9 +501,9 @@ namespace {{basePartOfNamespace}}.Controllers
         /// </summary>
         [HttpGet]
         [AuthGuard]
-        public virtual async Task<List<{{Helpers.ExtractTypeFromGenericType(property.Type)}}MainUIFormDTO>> GetOrdered{{property.Name}}For{{entity.Name}}({{entity.GetIdType(entities)}} id)
+        {{Helpers.GetPermissionAttribute(entity, CrudCodes.Read)}}public virtual async Task<List<{{Helpers.ExtractTypeFromGenericType(property.Type)}}MainUIFormDTO>> GetOrdered{{property.Name}}For{{entity.Name}}({{entity.GetIdType(entities)}} id)
         {
-            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().GetOrdered{{property.Name}}For{{entity.Name}}(id, {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            return await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().GetOrdered{{property.Name}}For{{entity.Name}}(id);
         }
 """);
             }
@@ -553,7 +549,7 @@ namespace {{basePartOfNamespace}}.Controllers
                 return null;
 
             string entityIdType = entity.GetIdType(entities);
-            string deletePermissionAttribute = Helpers.GetPermissionAttribute(entity, "Delete");
+            string deletePermissionAttribute = Helpers.GetPermissionAttribute(entity, CrudCodes.Delete);
 
             return $$"""
         /// <summary>
@@ -563,7 +559,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{deletePermissionAttribute}}public virtual async Task Delete{{entity.Name}}({{entityIdType}} id)
         {
-            await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}(id, {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}(id);
         }
 
         /// <summary>
@@ -573,7 +569,7 @@ namespace {{basePartOfNamespace}}.Controllers
         [AuthGuard]
         {{deletePermissionAttribute}}public virtual async Task Delete{{entity.Name}}List([FromBody] List<{{entityIdType}}> ids)
         {
-            await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}List(ids, {{Helpers.GetShouldAuthorizeEntityString(entity)}});
+            await _serviceProvider.GetRequiredService<{{entity.Name}}ServiceGenerated>().Delete{{entity.Name}}List(ids);
         }
 """;
         }

--- a/Spiderly.SourceGenerators/Net/Services/ServiceDeleteGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceDeleteGenerator.cs
@@ -53,19 +53,13 @@ namespace Spiderly.SourceGenerators.Net
         /// Deletes a single {{entity.Name}} entity with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="id">The ID of the entity to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task Delete{{entity.Name}}({{entityIdType}} id, bool authorize)
+        public async virtual Task Delete{{entity.Name}}({{entityIdType}} id)
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
                 await OnBefore{{entity.Name}}Delete(id);
 
 {{FlushStagedHookWritesSnippet}}
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Delete, "id")}}
-                }
 
                 List<{{entityIdType}}> listForDelete_{{deleteIterator}} = id.StructToList();
 
@@ -94,19 +88,13 @@ namespace Spiderly.SourceGenerators.Net
         /// Deletes multiple {{entity.Name}} entities with cascade delete handling for dependent entities.
         /// </summary>
         /// <param name="listForDelete_{{deleteIterator}}">The list of entity IDs to delete</param>
-        /// <param name="authorize">Whether to perform authorization check for Delete operation</param>
-        public async virtual Task Delete{{entity.Name}}List(List<{{entityIdType}}> listForDelete_{{deleteIterator}}, bool authorize)
+        public async virtual Task Delete{{entity.Name}}List(List<{{entityIdType}}> listForDelete_{{deleteIterator}})
         {
             await _deps.Context.WithTransactionAsync(async () =>
             {
                 await OnBefore{{entity.Name}}ListDelete(listForDelete_{{deleteIterator}});
 
 {{FlushStagedHookWritesSnippet}}
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Delete, $"listForDelete_{deleteIterator}")}}
-                }
 
 {{string.Join("\n\n", GetManyToOneDeleteQueries(entity, allEntities, "listForDelete", deleteIterator))}}
 

--- a/Spiderly.SourceGenerators/Net/Services/ServiceOneToManyGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceOneToManyGenerator.cs
@@ -72,17 +72,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves namebook DTOs for {{extractedPropertyEntity.Name}} entities in a many-to-many relationship with {{entity.Name}}.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
-        public async virtual Task<List<NamebookDTO<{{extractedPropertyEntityIdType}}>>> Get{{oneToManyProperty.Name}}NamebookListFor{{entity.Name}}({{entityIdType}} id, bool authorize)
+        public async virtual Task<List<NamebookDTO<{{extractedPropertyEntityIdType}}>>> Get{{oneToManyProperty.Name}}NamebookListFor{{entity.Name}}({{entityIdType}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 return await _deps.Context.DbSet<{{extractedPropertyEntity.Name}}>()
                     .AsNoTracking()
                     .Where(x => x.{{extractedEntityManyToManyProperty.Name}}.Any(x => x.Id == id))
@@ -99,17 +93,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves IDs of {{extractedPropertyEntity.Name}} entities in a many-to-many relationship with {{entity.Name}}.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of entity IDs</returns>
-        public async virtual Task<List<{{extractedPropertyEntityIdType}}>> Get{{oneToManyProperty.Name}}IdsFor{{entity.Name}}({{entityIdType}} id, bool authorize)
+        public async virtual Task<List<{{extractedPropertyEntityIdType}}>> Get{{oneToManyProperty.Name}}IdsFor{{entity.Name}}({{entityIdType}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 return await _deps.Context.DbSet<{{extractedPropertyEntity.Name}}>()
                     .AsNoTracking()
                     .Where(x => x.{{extractedEntityManyToManyProperty.Name}}.Any(x => x.Id == id))
@@ -176,9 +164,8 @@ namespace Spiderly.SourceGenerators.Net
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query (must be ordered)</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>LazyLoadSelectedIdsResultDTO containing selected IDs and total count</returns>
-        public async virtual Task<LazyLoadSelectedIdsResultDTO<{{extractedPropertyEntityIdType}}>> LazyLoadSelected{{oneToManyProperty.Name}}IdsFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{extractedPropertyEntity.Name}}> query, bool authorize)
+        public async virtual Task<LazyLoadSelectedIdsResultDTO<{{extractedPropertyEntityIdType}}>> LazyLoadSelected{{oneToManyProperty.Name}}IdsFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{extractedPropertyEntity.Name}}> query)
         {
             LazyLoadSelectedIdsResultDTO<{{extractedPropertyEntityIdType}}> lazyLoadSelectedIdsResultDTO = new();
 
@@ -190,13 +177,8 @@ namespace Spiderly.SourceGenerators.Net
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, $"({entityIdType})filterDTO.{entityIdType.GetTableFilterAdditionalFilterPropertyName()}")}}
-                }
-
                 var {{extractedPropertyEntity.Name.FirstCharToLower()}}Service = _deps.ServiceProvider.GetRequiredService<{{extractedPropertyEntity.Name}}ServiceGenerated>();
-                var paginationResult = await {{extractedPropertyEntity.Name.FirstCharToLower()}}Service.GetPaginated{{extractedPropertyEntity.Name}}List(filterDTO, query);
+                var paginationResult = await {{extractedPropertyEntity.Name.FirstCharToLower()}}Service.GetPaginated{{extractedPropertyEntity.Name}}Result(filterDTO, query);
 
                 lazyLoadSelectedIdsResultDTO.SelectedIds = await paginationResult.Query
                     .Select(x => x.Id)
@@ -255,17 +237,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves namebook DTOs for {{extractedPropertyEntity.Name}} entities related to a {{entity.Name}}.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
-        public async virtual Task<List<NamebookDTO<{{extractedPropertyEntityIdType}}>>> Get{{oneToManyProperty.Name}}NamebookListFor{{entity.Name}}({{entity.GetIdType(entities)}} id, bool authorize)
+        public async virtual Task<List<NamebookDTO<{{extractedPropertyEntityIdType}}>>> Get{{oneToManyProperty.Name}}NamebookListFor{{entity.Name}}({{entity.GetIdType(entities)}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 return await _deps.Context.DbSet<{{extractedPropertyEntity.Name}}>()
                     .AsNoTracking()
                     .Where(x => {{manyToOneProperty.GetForeignKeyAccessExpression(extractedPropertyEntity, entities)}} == id)
@@ -291,7 +267,7 @@ namespace Spiderly.SourceGenerators.Net
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<{{listEntitty.Name}}>> GetPaginated{{oneToManyProperty.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query)
+        public async virtual Task<PaginatedResult<{{listEntitty.Name}}>> GetPaginated{{oneToManyProperty.Name}}ResultFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -304,27 +280,21 @@ namespace Spiderly.SourceGenerators.Net
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>PaginatedResultDTO containing {{listEntitty.Name}}DTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<{{listEntitty.Name}}DTO>> GetPaginated{{oneToManyProperty.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<{{listEntitty.Name}}DTO>> GetPaginated{{oneToManyProperty.Name}}ListFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query)
         {
             PaginatedResult<{{listEntitty.Name}}> paginationResult = new();
             List<{{listEntitty.Name}}DTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginated{{oneToManyProperty.Name}}ListFor{{entity.Name}}(filterDTO, query);
+                paginationResult = await GetPaginated{{oneToManyProperty.Name}}ResultFor{{entity.Name}}(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<{{listEntitty.Name}}DTO>(Mapper.{{listEntitty.Name}}ProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, $"dtoList.Select(x => ({entity.GetIdType(allEntityClasses)})x.{m2mProperty.Name}Id).ToList()")}}
-                }
 
 {{ServiceReadGenerator.GetPopulateDTOWithBlobPartsForDTOList(entity.Properties)}}
             });
@@ -337,16 +307,15 @@ namespace Spiderly.SourceGenerators.Net
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> Export{{oneToManyProperty.Name}}ListToExcelFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> Export{{oneToManyProperty.Name}}ListToExcelFor{{entity.Name}}(FilterDTO filterDTO, IQueryable<{{listEntitty.Name}}> query, CancellationToken cancellationToken = default)
         {
             IQueryable<{{listEntitty.Name}}DTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<{{listEntitty.Name}}> paginationResult = await GetPaginated{{oneToManyProperty.Name}}ListFor{{entity.Name}}(filterDTO, query);
+                PaginatedResult<{{listEntitty.Name}}> paginationResult = await GetPaginated{{oneToManyProperty.Name}}ResultFor{{entity.Name}}(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query{{(hasId ? ".OrderBy(x => x.Id)" : "")}}
                     .Take(maxRows)
@@ -402,17 +371,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves all {{junctionEntity.Name}} DTOs for a {{entity.Name}}, including default records for {{otherSideEntity.Name}} entities without existing junction records.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of {{junctionEntity.Name}}DTO for all {{otherSideEntity.Name}} entities</returns>
-        public async virtual Task<List<{{junctionEntity.Name}}DTO>> Get{{oneToManyProperty.Name}}For{{entity.Name}}({{entityIdType}} id, bool authorize)
+        public async virtual Task<List<{{junctionEntity.Name}}DTO>> Get{{oneToManyProperty.Name}}For{{entity.Name}}({{entityIdType}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 var allOtherSideEntries = await _deps.Context.DbSet<{{otherSideEntity.Name}}>()
                     .AsNoTracking()
                     .OrderBy(x => x.Id)
@@ -554,17 +517,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Returns complete MainUIFormDTOs ordered by OrderNumber.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
         /// <returns>List of {{extractedPropertyEntity.Name}}MainUIFormDTO ordered by OrderNumber</returns>
-        public async virtual Task<List<{{extractedPropertyEntity.Name}}MainUIFormDTO>> GetOrdered{{property.Name}}For{{entity.Name}}({{entity.GetIdType(entities)}} id, bool authorize)
+        public async virtual Task<List<{{extractedPropertyEntity.Name}}MainUIFormDTO>> GetOrdered{{property.Name}}For{{entity.Name}}({{entity.GetIdType(entities)}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 List<{{extractedPropertyEntity.Name}}MainUIFormDTO> mainUIFormDTOList = new();
 
                 var ids = await _deps.Context.DbSet<{{extractedPropertyEntity.Name}}>()
@@ -576,7 +533,7 @@ namespace Spiderly.SourceGenerators.Net
 
                 var {{extractedPropertyEntity.Name.FirstCharToLower()}}Service = _deps.ServiceProvider.GetRequiredService<{{extractedPropertyEntity.Name}}ServiceGenerated>();
                 foreach (var id in ids)
-                    mainUIFormDTOList.Add(await {{extractedPropertyEntity.Name.FirstCharToLower()}}Service.Get{{extractedPropertyEntity.Name}}MainUIFormDTO(id, authorize));
+                    mainUIFormDTOList.Add(await {{extractedPropertyEntity.Name.FirstCharToLower()}}Service.Get{{extractedPropertyEntity.Name}}MainUIFormDTO(id));
 
                 return mainUIFormDTOList;
             });

--- a/Spiderly.SourceGenerators/Net/Services/ServiceReadGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceReadGenerator.cs
@@ -18,17 +18,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves the complete MainUIFormDTO for {{entity.Name}}, including the entity DTO and all related collections (one-to-many, many-to-many).
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>{{entity.Name}}MainUIFormDTO containing the entity DTO and related data</returns>
-        public async virtual Task<{{entity.Name}}MainUIFormDTO> Get{{entity.Name}}MainUIFormDTO({{entityIdType}} id, bool authorize)
+        public async virtual Task<{{entity.Name}}MainUIFormDTO> Get{{entity.Name}}MainUIFormDTO({{entityIdType}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 var result = new {{entity.Name}}MainUIFormDTO
                 {
 {{GetMainUIFormDTOInitializationProperties(entity, allEntities)}}
@@ -58,17 +52,11 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves a single {{entity.Name}} entity as a DTO with blob data populated.
         /// </summary>
         /// <param name="id">The ID of the {{entity.Name}} entity</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>{{entity.Name}}DTO with all blob properties populated</returns>
-        public async virtual Task<{{entity.Name}}DTO> Get{{entity.Name}}DTO({{entityIdType}} id, bool authorize)
+        public async virtual Task<{{entity.Name}}DTO> Get{{entity.Name}}DTO({{entityIdType}} id)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "id")}}
-                }
-
                 var dto = await _deps.Context.DbSet<{{entity.Name}}>()
                     .AsNoTracking()
                     .Where(x => x.Id == id).ProjectToType<{{entity.Name}}DTO>(Mapper.{{entity.Name}}ProjectToConfig())
@@ -89,7 +77,7 @@ namespace Spiderly.SourceGenerators.Net
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
         /// <returns>PaginatedResult containing the query and total record count</returns>
-        public async virtual Task<PaginatedResult<{{entity.Name}}>> GetPaginated{{entity.Name}}List(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query)
+        public async virtual Task<PaginatedResult<{{entity.Name}}>> GetPaginated{{entity.Name}}Result(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -102,27 +90,21 @@ namespace Spiderly.SourceGenerators.Net
         /// </summary>
         /// <param name="filterDTO">Filter and pagination parameters</param>
         /// <param name="query">The base query to paginate</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>PaginatedResultDTO containing {{entity.Name}}DTO list and total record count</returns>
-        public async virtual Task<PaginatedResultDTO<{{entity.Name}}DTO>> GetPaginated{{entity.Name}}List(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query, bool authorize)
+        public async virtual Task<PaginatedResultDTO<{{entity.Name}}DTO>> GetPaginated{{entity.Name}}List(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query)
         {
             PaginatedResult<{{entity.Name}}> paginationResult = new();
             List<{{entity.Name}}DTO> dtoList = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                paginationResult = await GetPaginated{{entity.Name}}List(filterDTO, query);
+                paginationResult = await GetPaginated{{entity.Name}}Result(filterDTO, query);
 
                 dtoList = await paginationResult.Query
                     .Skip(filterDTO.First)
                     .Take(filterDTO.Rows)
                     .ProjectToType<{{entity.Name}}DTO>(Mapper.{{entity.Name}}ProjectToConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "dtoList.Select(x => x.Id).ToList()")}}
-                }
 
 {{GetPopulateDTOWithBlobPartsForDTOList(entity.Properties)}}
             });
@@ -135,16 +117,15 @@ namespace Spiderly.SourceGenerators.Net
         /// </summary>
         /// <param name="filterDTO">Filter parameters for the export</param>
         /// <param name="query">The base query to export</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <param name="cancellationToken">Cancellation token</param>
         /// <returns>Excel file as byte array</returns>
-        public async virtual Task<byte[]> Export{{entity.Name}}ListToExcel(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query, bool authorize, CancellationToken cancellationToken = default)
+        public async virtual Task<byte[]> Export{{entity.Name}}ListToExcel(FilterDTO filterDTO, IQueryable<{{entity.Name}}> query, CancellationToken cancellationToken = default)
         {
             IQueryable<{{entity.Name}}DTO> exportQuery = null;
 
             await _deps.Context.WithTransactionAsync(async () =>
             {
-                PaginatedResult<{{entity.Name}}> paginationResult = await GetPaginated{{entity.Name}}List(filterDTO, query);
+                PaginatedResult<{{entity.Name}}> paginationResult = await GetPaginated{{entity.Name}}Result(filterDTO, query);
                 int maxRows = _deps.ExcelSettings.ExcelExportMaxRows;
                 exportQuery = paginationResult.Query
                     .OrderBy(x => x.Id)
@@ -164,19 +145,13 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves a list of {{entity.Name}} entities without pagination.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of {{entity.Name}} entities</returns>
-        public async virtual Task<List<{{entity.Name}}>> Get{{entity.Name}}List(IQueryable<{{entity.Name}}> query, bool authorize)
+        public async virtual Task<List<{{entity.Name}}>> Get{{entity.Name}}List(IQueryable<{{entity.Name}}> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
                 var result = await query
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "result.Select(x => x.Id).ToList()")}}
-                }
 
                 return result;
             });
@@ -186,9 +161,8 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves a list of {{entity.Name}} DTOs without pagination, with blob data populated.
         /// </summary>
         /// <param name="query">The query to execute</param>
-        /// <param name="authorize">Whether to perform authorization check for Read operation</param>
         /// <returns>List of {{entity.Name}}DTO with blob properties populated</returns>
-        public async virtual Task<List<{{entity.Name}}DTO>> Get{{entity.Name}}DTOList(IQueryable<{{entity.Name}}> query, bool authorize)
+        public async virtual Task<List<{{entity.Name}}DTO>> Get{{entity.Name}}DTOList(IQueryable<{{entity.Name}}> query)
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
@@ -196,11 +170,6 @@ namespace Spiderly.SourceGenerators.Net
                     .AsNoTracking()
                     .ProjectToType<{{entity.Name}}DTO>(Mapper.{{entity.Name}}ToDTOConfig())
                     .ToListAsync();
-
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, "dtoList.Select(x => x.Id).ToList()")}}
-                }
 
 {{GetPopulateDTOWithBlobPartsForDTOList(entity.Properties)}}
 
@@ -217,7 +186,7 @@ namespace Spiderly.SourceGenerators.Net
             List<string> result = new();
 
             result.Add($$"""
-                    {{entity.Name}}DTO = await Get{{entity.Name}}DTO(id, false),
+                    {{entity.Name}}DTO = await Get{{entity.Name}}DTO(id),
 """);
 
             foreach (SpiderlyProperty property in entity.Properties
@@ -235,25 +204,25 @@ namespace Spiderly.SourceGenerators.Net
                 if (property.HasUIOrderedOneToManyAttribute())
                 {
                     result.Add($$"""
-                    Ordered{{property.Name}}MainUIFormDTO = await GetOrdered{{property.Name}}For{{entity.Name}}(id, false),
+                    Ordered{{property.Name}}MainUIFormDTO = await GetOrdered{{property.Name}}For{{entity.Name}}(id),
 """);
                 }
                 else if (property.IsMultiSelectControlType())
                 {
                     result.Add($$"""
-                    {{property.Name}}Ids = await Get{{property.Name}}IdsFor{{entity.Name}}(id, false),
+                    {{property.Name}}Ids = await Get{{property.Name}}IdsFor{{entity.Name}}(id),
 """);
                 }
                 else if (property.IsMultiAutocompleteControlType())
                 {
                     result.Add($$"""
-                    {{property.Name}}NamebookDTOList = await Get{{property.Name}}NamebookListFor{{entity.Name}}(id, false),
+                    {{property.Name}}NamebookDTOList = await Get{{property.Name}}NamebookListFor{{entity.Name}}(id),
 """);
                 }
                 else if (property.HasComplexManyToManyListAttribute())
                 {
                     result.Add($$"""
-                    {{property.Name}} = await Get{{property.Name}}For{{entity.Name}}(id, false),
+                    {{property.Name}} = await Get{{property.Name}}For{{entity.Name}}(id),
 """);
                 }
             }
@@ -399,24 +368,15 @@ namespace Spiderly.SourceGenerators.Net
         /// <param name="limit">Maximum number of results to return</param>
         /// <param name="filter">Text filter for {{autocompleteEntityDisplayName}}</param>
         /// <param name="query">Base query for {{autocompleteEntity.Name}} entities</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
-        /// <param name="{{entity.Name.FirstCharToLower()}}Id">Optional {{entity.Name}} ID for context-specific authorization</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
         public async virtual Task<List<NamebookDTO<{{autocompleteEntityIdType}}>>> Get{{property.Name}}AutocompleteListFor{{entity.Name}}(
             int limit,
             string filter,
-            IQueryable<{{autocompleteEntity.Name}}> query,
-            bool authorize,
-            {{entity.GetIdType(allEntities)}}? {{entity.Name.FirstCharToLower()}}Id = null
+            IQueryable<{{autocompleteEntity.Name}}> query
         )
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, $"{entity.Name.FirstCharToLower()}Id")}}
-                }
-
                 if (!string.IsNullOrEmpty(filter))
                     query = query.Where(x => x.{{autocompleteEntityDisplayName}}.ToLower().Contains(filter.ToLower()));
 
@@ -447,22 +407,13 @@ namespace Spiderly.SourceGenerators.Net
         /// Retrieves dropdown options for the {{property.Name}} many-to-one relationship in {{entity.Name}}.
         /// </summary>
         /// <param name="query">Base query for {{dropdownEntity.Name}} entities</param>
-        /// <param name="authorize">Whether to perform authorization check</param>
-        /// <param name="{{entity.Name.FirstCharToLower()}}Id">Optional {{entity.Name}} ID for context-specific authorization</param>
         /// <returns>List of NamebookDTO containing ID and DisplayName</returns>
         public async virtual Task<List<NamebookDTO<{{dropdownEntityIdType}}>>> Get{{property.Name}}DropdownListFor{{entity.Name}}(
-            IQueryable<{{dropdownEntity.Name}}> query,
-            bool authorize,
-            {{entity.GetIdType(allEntities)}}? {{entity.Name.FirstCharToLower()}}Id = null
+            IQueryable<{{dropdownEntity.Name}}> query
         )
         {
             return await _deps.Context.WithTransactionAsync(async () =>
             {
-                if (authorize)
-                {
-                    {{ServicesGenerator.GetAuthorizeEntityMethodCall(entity.Name, CrudCodes.Read, $"{entity.Name.FirstCharToLower()}Id")}}
-                }
-
                 var result = await query
                     .AsNoTracking()
                     .Select(x => new NamebookDTO<{{dropdownEntityIdType}}>

--- a/Spiderly.SourceGenerators/Net/Services/ServiceSaveGenerator.cs
+++ b/Spiderly.SourceGenerators/Net/Services/ServiceSaveGenerator.cs
@@ -336,7 +336,7 @@ namespace Spiderly.SourceGenerators.Net
                 result.Add($$"""
                 var all{{property.Name}}Query = await GetAll{{property.Name}}QueryFor{{entity.Name}}(_deps.Context.DbSet<{{extractedEntity.Name}}>());
                 var {{property.Name.FirstCharToLower()}}Service = _deps.ServiceProvider.GetRequiredService<{{extractedEntity.Name}}ServiceGenerated>();
-                var {{property.Name.FirstCharToLower()}}PaginatedResult = await {{property.Name.FirstCharToLower()}}Service.GetPaginated{{extractedEntity.Name}}List(saveBodyDTO.{{property.Name}}TableFilter, all{{property.Name}}Query);
+                var {{property.Name.FirstCharToLower()}}PaginatedResult = await {{property.Name.FirstCharToLower()}}Service.GetPaginated{{extractedEntity.Name}}Result(saveBodyDTO.{{property.Name}}TableFilter, all{{property.Name}}Query);
                 await Update{{property.Name}}WithLazyTableSelectionFor{{entity.Name}}({{property.Name.FirstCharToLower()}}PaginatedResult.Query, savedDTO.Id, saveBodyDTO);
 """);
 
@@ -395,7 +395,7 @@ namespace Spiderly.SourceGenerators.Net
             foreach (SpiderlyProperty property in entity.GetComplexManyToManyListProperties())
             {
                 result.Add($$"""
-                    {{property.Name}} = await {{servicePrefix}}Get{{property.Name}}For{{entity.Name}}(savedDTO.Id, false),
+                    {{property.Name}} = await {{servicePrefix}}Get{{property.Name}}For{{entity.Name}}(savedDTO.Id),
 """);
             }
 

--- a/Spiderly.SourceGenerators/Shared/Helpers.cs
+++ b/Spiderly.SourceGenerators/Shared/Helpers.cs
@@ -154,16 +154,27 @@ namespace Spiderly.SourceGenerators.Shared
             return enumMembers;
         }
 
+        /// <summary>
+        /// The single source for the <c>{Crud}{EntityName}</c> permission-code convention (e.g. <c>ReadProduct</c>).
+        /// Both the generated <c>PermissionCodes</c> constants (via <see cref="GetPermissionCodesForEntites"/>) and the
+        /// boundary <c>[HasPermission(...)]</c> attribute (via <see cref="GetPermissionAttribute"/>) build their codes
+        /// through here, so the attribute can never drift from a real permission code.
+        /// </summary>
+        public static string GetEntityPermissionCode(SpiderlyClass entity, CrudCodes crudCode)
+        {
+            return $"{crudCode}{entity.Name}";
+        }
+
         public static List<string> GetPermissionCodesForEntites(List<SpiderlyClass> entities)
         {
             List<string> result = new();
 
             foreach (SpiderlyClass entity in entities)
             {
-                result.Add($"Read{entity.Name}");
-                result.Add($"Update{entity.Name}");
-                result.Add($"Insert{entity.Name}");
-                result.Add($"Delete{entity.Name}");
+                result.Add(GetEntityPermissionCode(entity, CrudCodes.Read));
+                result.Add(GetEntityPermissionCode(entity, CrudCodes.Update));
+                result.Add(GetEntityPermissionCode(entity, CrudCodes.Insert));
+                result.Add(GetEntityPermissionCode(entity, CrudCodes.Delete));
             }
 
             return result;
@@ -188,15 +199,15 @@ namespace Spiderly.SourceGenerators.Shared
         /// Returns the boundary authorization attribute for a CRUD operation on <paramref name="entity"/> —
         /// e.g. <c>[HasPermission("ReadProduct")]</c> — with a trailing newline + indent so it can be emitted
         /// inline before a generated action, or an empty string when the entity opts out via [DoNotAuthorize].
-        /// <paramref name="crudPrefix"/> is the permission-code prefix ("Read" / "Delete" / …), matching the
-        /// codes emitted by the permission-codes generator.
+        /// The permission code comes from <see cref="GetEntityPermissionCode"/> — the same source as the generated
+        /// <c>PermissionCodes</c> constants — so the attribute always references a real permission code.
         /// </summary>
-        public static string GetPermissionAttribute(SpiderlyClass entity, string crudPrefix)
+        public static string GetPermissionAttribute(SpiderlyClass entity, CrudCodes crudCode)
         {
             if (ShouldAuthorizeEntity(entity) == false)
                 return "";
 
-            return $"[HasPermission(\"{crudPrefix}{entity.Name}\")]\n        ";
+            return $"[HasPermission(\"{GetEntityPermissionCode(entity, crudCode)}\")]\n        ";
         }
 
         #endregion


### PR DESCRIPTION
## Phase 2d — coarse authz at the boundary

Follow-up to #263. Reads and deletes are now authorized **solely at the controller boundary** via `[HasPermission]`; the in-service `bool authorize` plumbing is gone, and the now-dead pieces are removed. Refs #268.

### What changed
- **Drop in-service read/delete authz** — `Service{Read,Delete,OneToMany}Generator` lose the `bool authorize` param + `if (authorize) Authorize{X}{Read,Delete}AndThrow(...)` blocks; `AuthorizationServicesGenerator` stops emitting those `AndThrow` methods. **Update/Insert stay** (Save's authz is data-dependent, see #265).
- **Boundary `[HasPermission]` on nested reads** — autocomplete, dropdown, lazy-load, complex-M2M readonly table, ordered O2M.
- **Remove the vestigial `{entity}Id`** from autocomplete/dropdown end-to-end (backend + Angular generators).
- **`AddSpiderlyAuthorization<T>()`** — new framework extension bundling the `[HasPermission]` handler + the `AuthorizationServiceBase`→generated-service forwarding (was two raw registrations in the init template, where the handler could silently drift from the provider).
- **Runtime authz tidy** — `IsAuthenticated` derived from `UserId`; identity reading unified on `ISpiderlyPrincipalAccessor` (deleted the orphaned `Helper.GetCurrentUserId*` / `IsUserLoggedIn`); policy-provider per-endpoint cache opt-in; single-source `GetEntityPermissionCode`.
- init template: `GetCurrentUser` drops the authorize arg; the `AuthorizeUserReadAndThrow` override is removed.

### Verification
Builds clean; service-snapshot + guardrail + Shared auth tests green locally (7 snapshots regenerated, authz-only deltas). **The CI e2e job is the key check** — it compiles a generated app + Angular frontend, covering the controller/template/Angular-generator changes that can't be unit-tested.

### Downstream (not in this PR)
- Rebase onto `develop` once #262 + #263 merge.
- **pa-cms migration** (when it bumps to this Spiderly version — it's on published 19.8.4 today, so untouched here): `AuthorizeUserReadAndThrow` override + `AuthorizeTagReadAndThrow` call + `GetUserDTO(., false)` + 6 `Delete{X}(id, false)` callsites, plus the frontend autocomplete callers passing the dropped id.
- Deferred quality cleanups tracked in #269.
