### PR TITLE
ci(review): skip Verify snapshot fixtures in the gate review

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,6 +32,6 @@ jobs:
 
         CONVENTIONS (advisory): public members in shipped packages (Spiderly.Shared, Spiderly.Security, Spiderly.Infrastructure) need /// <summary> XML docs; remove dead code left by deletions; reuse existing helpers instead of duplicating; logic errors; security.
 
-        SKIP: framework-metadata.json, any *.generated.md, Angular/projects/spiderly/agent/**, and anything under obj/, bin/, node_modules/, or .source/.
+        SKIP: framework-metadata.json, any *.generated.md, any *.verified.cs (Verify snapshot fixtures — review the generator that produces them, not the approved output), Angular/projects/spiderly/agent/**, and anything under obj/, bin/, node_modules/, or .source/.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Adds `*.verified.cs` (Verify snapshot fixtures) to the gate review's SKIP list, alongside the generated artifacts already skipped (`*.generated.md`, `framework-metadata.json`).

**Why:** the autonomous reviewer reads the full PR diff. On a large source-generator PR the regenerated snapshots dominate it — #270 (Phase 2d) was **56% snapshot lines (518/927)**. The reviewer spent turns on that mechanical, derived output and hit `--max-turns` before writing `claude-verdict.json`, so the gate failed closed on a verified-correct PR (it was admin-merged). Snapshots are approved generated output; the logic worth reviewing is the generator that produces them.

Defense-in-depth follow-up (not here): a modest `--max-turns` headroom bump in `ci-workflows` for genuinely large hand-written diffs.