### PR TITLE
ci: guard the main-ancestor-of-develop release invariant

### DIFF
--- a/.github/workflows/develop-invariant.yml
+++ b/.github/workflows/develop-invariant.yml
@@ -1,0 +1,37 @@
+name: develop invariant
+
+# Guards the linear release model: main must always be an ancestor of develop, so release.yml's
+# fast-forward of main onto develop keeps working. A direct/hotfix commit to main that isn't
+# reconciled back into develop breaks this — and today it only surfaces (loudly) at the *next*
+# release (cf. spiderly-website#75, where a forgotten rebase sat until it broke a release).
+# This check moves detection to the next develop push, so the one-line fix can happen immediately:
+#   git checkout develop && git rebase origin/main && git push --force-with-lease
+#
+# It runs from develop (push trigger), not on a schedule — scheduled workflows only run from the
+# default branch (main), which is updated solely by release.yml's fast-forward, so a schedule
+# could never see an unreleased develop.
+
+on:
+  push:
+    branches: [develop]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  main-is-ancestor-of-develop:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          fetch-depth: 0
+      - name: main must be an ancestor of develop
+        run: |
+          git fetch --quiet origin main develop
+          if git merge-base --is-ancestor origin/main origin/develop; then
+            echo "✓ main is an ancestor of develop — the release fast-forward will succeed."
+            exit 0
+          fi
+          echo "::error title=main diverged from develop::main has commit(s) not in develop — a direct/hotfix commit to main was not reconciled into develop. Fix: git checkout develop && git rebase origin/main && git push --force-with-lease. Until then release.yml's fast-forward of main will fail."
+          exit 1


### PR DESCRIPTION
## What

Adds `.github/workflows/develop-invariant.yml` — a lightweight CI check that fails the **next develop push** if `main` is no longer an ancestor of `develop`.

## Why

We keep fast hotfixes to the default branch (`main`). The linear release model requires `main` to always be an ancestor of `develop` so `release.yml` can fast-forward `main` onto `develop`. A direct/hotfix commit to `main` that isn't reconciled back into `develop` breaks that — but today it only surfaces **loudly at the next release** (this is exactly what bit spiderly-website#75: a forgotten rebase sat unreconciled until it broke a release run).

This moves detection earlier. The fix when it fires is one line:
```
git checkout develop && git rebase origin/main && git push --force-with-lease
```

## Design notes

- **Runs from `develop` (push trigger), not on a schedule** — scheduled workflows only run from the default branch (`main`), which is updated solely by `release.yml`'s fast-forward, so a schedule could never observe an unreleased `develop`.
- Read-only (`permissions: contents: read`); the failed check + GitHub's failure email is the alert.
- Passes on introduction (`main` is currently an ancestor of `develop`).