### PR TITLE
feat(agent-evals): Spiderly-vs-plain benchmark arms + showcase scaffolding

### DIFF
--- a/.github/workflows/agent-evals.yml
+++ b/.github/workflows/agent-evals.yml
@@ -94,8 +94,10 @@ jobs:
 
       # --- Build the `spiderly-app` fixture in CI (the pre-task state) ---
       # Mirrors ci.yml's integration-test scaffold: build+pack packages, publish the Angular lib to a
-      # local Verdaccio, install the CLI, then `spiderly init`. Only the BACKEND is kept as the
-      # fixture — the add-validator verifier is dotnet-build-only (no Postgres, no Angular, no boot).
+      # local Verdaccio, install the CLI, then `spiderly init`. The WHOLE real init app is kept as the
+      # fixture — guidance included (AGENTS.md + docs + .claude/skills) — so the with-Spiderly arm
+      # mirrors what a real Spiderly developer has. Stripping it to Backend-only would delete exactly
+      # that guidance (the bug we fixed one level up). UNVALIDATED until the first workflow_dispatch.
       - name: Build and pack all Spiderly packages
         run: |
           dotnet restore
@@ -152,6 +154,19 @@ jobs:
           # unlike ci.yml's integration-test, which boots the app and so sets up Postgres first.
           spiderly init --name "${{ env.TEST_APP_NAME }}" --db skip
 
+      # Set up the agent guidance the WITH-Spiderly arm depends on. `spiderly init` already runs
+      # agent-sync, but agent-sync SOFT-SKIPS when node_modules isn't installed yet — so install the
+      # app's frontend deps (pulls `spiderly` from Verdaccio → node_modules/spiderly/agent), then run
+      # agent-sync explicitly to write AGENTS.md + the docs pointer + .claude/skills/spiderly-*.
+      # NOTE: assumes `spiderly init` scaffolds a `Frontend/` — verify on the first real run.
+      - name: Sync Spiderly agent guidance into the app
+        run: |
+          export PATH="$HOME/.dotnet/tools:$PATH"
+          cd "${{ env.APP_FOLDER }}/Frontend"
+          npm install
+          cd "${{ env.APP_FOLDER }}"
+          spiderly agent-sync
+
       # Apply the eval overlay: the add-validator PRE-task Product (Name present, NO validation).
       # We deliberately do NOT run tests/e2e-fixtures/setup.sh — that overlay's Product.Name already
       # has [Required]/[MaxLength(100)], which would make the task pre-satisfied (a no-op would pass).
@@ -170,11 +185,19 @@ jobs:
           dotnet restore
           dotnet build -c Release --no-restore
 
-      - name: Stage fixture (Backend only, no bin/obj)
+      - name: Stage fixture (full real `spiderly init` app — guidance kept)
         run: |
+          export PATH="$HOME/.dotnet/tools:$PATH"
           DEST="$GITHUB_WORKSPACE/tools/agent-evals/fixtures/spiderly-app"
           mkdir -p "$DEST"
-          rsync -a --exclude bin --exclude obj "${{ env.APP_FOLDER }}/Backend" "$DEST/"
+          # Keep the WHOLE app — Backend + Frontend + the node_modules/spiderly/agent bundle the
+          # guidance points at + AGENTS.md + CLAUDE.md + .claude/skills — dropping only .NET build
+          # output. The with-Spiderly arm must mirror a real developer's app; stripping the guidance is
+          # the bug we fixed. (-a preserves the .claude/skills symlinks agent-sync created.)
+          rsync -a --exclude 'bin' --exclude 'obj' "${{ env.APP_FOLDER }}/" "$DEST/"
+          # The .claude/skills symlinks were created against the build-time app path, which won't exist
+          # at eval time — re-point them at the staged bundle so they resolve in each run's copy.
+          cd "$DEST" && spiderly agent-sync
 
       # --- Run the agents (Claude CLI already installed + auth-verified above) ---
       - name: Run evals

--- a/tools/agent-evals/agents/codex.mjs
+++ b/tools/agent-evals/agents/codex.mjs
@@ -1,0 +1,66 @@
+import { run } from '../lib/exec.mjs';
+
+// Parse Codex `exec --json` output. Codex emits a JSONL event stream (thread.started,
+// turn.started, turn.completed, item.*, error) — NOT Claude's single JSON object. Token usage
+// lives on `turn.completed` events; usage totals are cumulative per the session JSONL, so the
+// run total is the LAST turn.completed's usage. (Needs confirming on a live run — if the --json
+// stdout stream turns out to report per-turn deltas instead, switch to summing output_tokens.)
+export function parseCodexUsage(stdout) {
+  const completed = [];
+  for (const line of stdout.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    let ev;
+    try { ev = JSON.parse(trimmed); } catch { continue; } // ignore non-JSON / partial lines
+    if (ev?.type === 'turn.completed') completed.push(ev);
+  }
+  const usage = completed[completed.length - 1]?.usage ?? {};
+  return {
+    tokens: usage.output_tokens ?? 0, // match claude.mjs: `tokens` = output tokens
+    turns: completed.length,
+    usage,
+  };
+}
+
+// Real Codex headless run (`codex exec --json`). Edits the workspace in place over multiple turns.
+// Auth: ChatGPT subscription sign-in (a CODEX subscription secret in CI). Subscription-only by
+// design — do NOT add a per-use OpenAI API key.
+// NOTE: Date.now() is fine here — this is an ordinary Node CLI, not a Workflow() sandbox.
+//
+// THREE THINGS TO CONFIRM AGAINST A LIVE CODEX BEFORE A REAL EVAL (deliberately not guessed):
+//   1. Sandbox/approval flag — must allow unattended file edits AND running `dotnet build`
+//      (incl. NuGet network restore). `--dangerously-bypass-approvals-and-sandbox` is the full
+//      bypass that mirrors claude's `bypassPermissions`; verify the exact spelling + that network
+//      is permitted on the installed version (`--full-auto` may block network restore).
+//   2. Turn cap — Codex `exec` has no `--max-turns` equivalent of claude's; `maxTurns` is accepted
+//      for interface parity but not passed. Confirm how Codex bounds a runaway session.
+//   3. Cost — Codex emits NO dollar figure. costUsd stays 0 here; the run cost is derived centrally
+//      from `usage` x list price at the reporting step (pricing.mjs, TODO).
+export default {
+  name: 'codex',
+  async run({ workspaceDir, prompt, maxTurns }) {
+    void maxTurns; // see note 2 — no Codex equivalent; kept for interface parity
+    const start = Date.now();
+    const res = run('codex', [
+      'exec',
+      '--json',
+      // Eval workspaces are standalone dirs that may live outside a git repo (or in a temp dir);
+      // `codex exec` refuses to run outside a repo without this flag. Harmless when nested in one.
+      '--skip-git-repo-check',
+      '--dangerously-bypass-approvals-and-sandbox',
+      prompt,
+    ], { cwd: workspaceDir, shell: process.platform === 'win32', timeoutMs: 20 * 60 * 1000 });
+    const wallMs = Date.now() - start;
+
+    const { tokens, turns, usage } = parseCodexUsage(res.stdout);
+
+    // On failure, surface both streams — matrix.json keeps only agentMeta, so this log is the only
+    // place the cause (auth/quota/crash) is visible; without it a failure looks like a 0-turn no-op.
+    if (res.code !== 0) {
+      console.error(`[codex] exit ${res.code}\n[stdout] ${res.stdout.trim().slice(-1500)}\n[stderr] ${res.stderr.trim().slice(-800)}`);
+    }
+    const transcript = res.stdout + (res.stderr.trim() ? `\n[stderr]\n${res.stderr.trim()}` : '');
+
+    return { transcript, tokens, costUsd: 0, turns, wallMs, cleanExit: res.code === 0, usage };
+  },
+};

--- a/tools/agent-evals/agents/codex.test.mjs
+++ b/tools/agent-evals/agents/codex.test.mjs
@@ -1,0 +1,54 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { parseCodexUsage } from './codex.mjs';
+
+// Codex `exec --json` emits a JSONL event stream (thread.started, turn.started,
+// turn.completed, item.*, error); token usage lives on `turn.completed` events.
+test('parseCodexUsage reads output tokens and turn count from one completed turn', () => {
+  const stdout = [
+    '{"type":"thread.started","thread_id":"t1"}',
+    '{"type":"turn.started"}',
+    '{"type":"turn.completed","usage":{"input_tokens":1200,"cached_input_tokens":1000,"output_tokens":345,"reasoning_output_tokens":20}}',
+  ].join('\n');
+  const { tokens, turns, usage } = parseCodexUsage(stdout);
+  assert.equal(tokens, 345);
+  assert.equal(turns, 1);
+  assert.equal(usage.input_tokens, 1200);
+});
+
+test('parseCodexUsage uses the last (cumulative) turn for totals and counts every turn', () => {
+  const stdout = [
+    '{"type":"turn.started"}',
+    '{"type":"turn.completed","usage":{"input_tokens":500,"output_tokens":100}}',
+    '{"type":"turn.started"}',
+    '{"type":"turn.completed","usage":{"input_tokens":1500,"output_tokens":380}}',
+  ].join('\n');
+  const { tokens, turns } = parseCodexUsage(stdout);
+  assert.equal(turns, 2);
+  assert.equal(tokens, 380); // cumulative totals → the last turn carries the run total
+});
+
+test('parseCodexUsage ignores non-turn.completed events and malformed/truncated lines', () => {
+  const stdout = [
+    '{"type":"thread.started"}',
+    '{"type":"item.completed","item":{"type":"reasoning"}}',
+    'not json at all',
+    '{"type":"turn.completed","usage":{"input_tokens":900,"output_tokens":210}}',
+    '{"type":"item.completed","item":{"type":"command_exec', // truncated trailing line
+  ].join('\n');
+  const { tokens, turns } = parseCodexUsage(stdout);
+  assert.equal(turns, 1);
+  assert.equal(tokens, 210);
+});
+
+test('parseCodexUsage returns zeroes when no turn completed (crash / turn.failed)', () => {
+  const stdout = [
+    '{"type":"thread.started"}',
+    '{"type":"turn.started"}',
+    '{"type":"turn.failed","error":{"message":"boom"}}',
+  ].join('\n');
+  const { tokens, turns, usage } = parseCodexUsage(stdout);
+  assert.equal(tokens, 0);
+  assert.equal(turns, 0);
+  assert.deepEqual(usage, {});
+});

--- a/tools/agent-evals/cli.mjs
+++ b/tools/agent-evals/cli.mjs
@@ -8,10 +8,18 @@ import { resultsRoot } from './lib/paths.mjs';
 import noop from './agents/noop.mjs';
 import oracle from './agents/oracle.mjs';
 import claude from './agents/claude.mjs';
+import codex from './agents/codex.mjs';
 import { provision as agnostic } from './tracks/agnostic.mjs';
+import { provision as plainNet } from './tracks/plain-net.mjs';
+import { provision as spiderly } from './tracks/spiderly.mjs';
 
-const agentsByName = { noop, oracle, claude };
-const tracksByName = { agnostic };
+const agentsByName = { noop, oracle, claude, codex };
+// Framework axis (the case study): 'spiderly' = the WITH-Spiderly arm (a real, untouched
+// `spiderly init` app — guidance included); 'plain-net' = the WITHOUT-Spiderly arm (frozen thin
+// plain-.NET baseline). 'agnostic' is the older guidance-axis track (lean doc reconstruction), kept
+// for that experiment. NOTE: the showcase has its OWN bare `plain` track in showcase.mjs —
+// deliberately NOT wired into the scored benchmark here.
+const tracksByName = { spiderly, agnostic, 'plain-net': plainNet };
 
 function die(msg) {
   console.error(`agent-evals: ${msg}`);
@@ -20,7 +28,7 @@ function die(msg) {
 
 function parseArgs(argv) {
   if (argv[0] === 'run') argv = argv.slice(1); // optional `run` subcommand
-  const a = { agents: ['claude'], track: 'agnostic', tier: undefined, reps: 3 };
+  const a = { agents: ['claude'], track: 'agnostic', tier: undefined, task: undefined, reps: 3 };
   for (let i = 0; i < argv.length; i++) {
     const k = argv[i].startsWith('--') ? argv[i].slice(2) : null;
     if (!k) die(`unexpected argument: ${argv[i]}`);
@@ -29,6 +37,7 @@ function parseArgs(argv) {
     if (k === 'agents') { a.agents = v.split(',').filter(Boolean); i++; }
     else if (k === 'track') { a.track = v; i++; }
     else if (k === 'tier') { a.tier = v; i++; }
+    else if (k === 'task') { a.task = v; i++; }
     else if (k === 'reps') { a.reps = Number(v); i++; }
     else die(`unknown flag: --${k}`);
   }
@@ -39,7 +48,7 @@ function parseArgs(argv) {
 
 const args = parseArgs(process.argv.slice(2));
 const runId = new Date().toISOString().replace(/[:.]/g, '-');
-const tasks = loadTasks({ tier: args.tier });
+const tasks = loadTasks({ tier: args.tier, taskId: args.task });
 if (!tasks.length) { console.error('No tasks found'); process.exit(1); }
 
 const matrix = await runEval({ ...args, agentsByName, tracksByName, tasks, runId });

--- a/tools/agent-evals/fixtures/plain-app/Backend/Backend.csproj
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Backend.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.15" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="9.0.*" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.*">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="9.0.*" />
+  </ItemGroup>
+
+</Project>

--- a/tools/agent-evals/fixtures/plain-app/Backend/Backend.http
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Backend.http
@@ -1,0 +1,6 @@
+@Backend_HostAddress = http://localhost:5257
+
+GET {{Backend_HostAddress}}/weatherforecast/
+Accept: application/json
+
+###

--- a/tools/agent-evals/fixtures/plain-app/Backend/Controllers/AuthController.cs
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Controllers/AuthController.cs
@@ -1,0 +1,38 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Backend.Controllers;
+
+// Thin baseline auth: a single test account (from the "Jwt" config section) exchanges credentials
+// for a JWT. Enough for the eval to authenticate against [Authorize] endpoints the agent adds — it
+// is NOT a real user store. The no-Spiderly baseline ships working auth so the agent doesn't
+// rebuild it (see fixtures/plain-app README).
+[ApiController]
+[Route("api/[controller]")]
+public class AuthController(IConfiguration config) : ControllerBase
+{
+    public record LoginRequest(string Username, string Password);
+    public record LoginResponse(string Token);
+
+    [HttpPost("login")]
+    public ActionResult<LoginResponse> Login(LoginRequest request)
+    {
+        var jwt = config.GetSection("Jwt");
+        if (request.Username != jwt["TestUser"] || request.Password != jwt["TestPassword"])
+            return Unauthorized();
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt["Key"]!));
+        var creds = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(
+            issuer: jwt["Issuer"],
+            audience: jwt["Audience"],
+            claims: [new Claim(ClaimTypes.Name, request.Username)],
+            expires: DateTime.UtcNow.AddHours(1),
+            signingCredentials: creds);
+
+        return new LoginResponse(new JwtSecurityTokenHandler().WriteToken(token));
+    }
+}

--- a/tools/agent-evals/fixtures/plain-app/Backend/Data/AppDbContext.cs
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Data/AppDbContext.cs
@@ -1,0 +1,10 @@
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Data;
+
+// Thin EF Core context for the no-Spiderly baseline. Intentionally empty: feature entities, their
+// DbSet<T>s, and migrations are added by the agent per task. Nothing here is generated.
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+}

--- a/tools/agent-evals/fixtures/plain-app/Backend/Program.cs
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Program.cs
@@ -1,0 +1,52 @@
+using System.Text;
+using Backend.Data;
+using Microsoft.AspNetCore.Authentication.JwtBearer;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.IdentityModel.Tokens;
+
+var builder = WebApplication.CreateBuilder(args);
+
+// EF Core (PostgreSQL). The context starts empty — the agent adds feature entities + migrations.
+builder.Services.AddDbContext<AppDbContext>(options =>
+    options.UseNpgsql(builder.Configuration.GetConnectionString("Default")));
+
+// JWT bearer authentication. Validation params come from the "Jwt" config section.
+var jwt = builder.Configuration.GetSection("Jwt");
+var signingKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwt["Key"]!));
+builder.Services
+    .AddAuthentication(JwtBearerDefaults.AuthenticationScheme)
+    .AddJwtBearer(options =>
+    {
+        options.TokenValidationParameters = new TokenValidationParameters
+        {
+            ValidateIssuer = true,
+            ValidateAudience = true,
+            ValidateLifetime = true,
+            ValidateIssuerSigningKey = true,
+            ValidIssuer = jwt["Issuer"],
+            ValidAudience = jwt["Audience"],
+            IssuerSigningKey = signingKey,
+        };
+    });
+builder.Services.AddAuthorization();
+
+builder.Services.AddControllers();
+// Learn more about configuring OpenAPI at https://aka.ms/aspnet/openapi
+builder.Services.AddOpenApi();
+
+var app = builder.Build();
+
+// Configure the HTTP request pipeline.
+if (app.Environment.IsDevelopment())
+{
+    app.MapOpenApi();
+}
+
+app.UseHttpsRedirection();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapControllers();
+
+app.Run();

--- a/tools/agent-evals/fixtures/plain-app/Backend/Properties/launchSettings.json
+++ b/tools/agent-evals/fixtures/plain-app/Backend/Properties/launchSettings.json
@@ -1,0 +1,23 @@
+﻿{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "http://localhost:5257",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": false,
+      "applicationUrl": "https://localhost:7228;http://localhost:5257",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/tools/agent-evals/fixtures/plain-app/Backend/appsettings.Development.json
+++ b/tools/agent-evals/fixtures/plain-app/Backend/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/tools/agent-evals/fixtures/plain-app/Backend/appsettings.json
+++ b/tools/agent-evals/fixtures/plain-app/Backend/appsettings.json
@@ -1,0 +1,19 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  },
+  "AllowedHosts": "*",
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Port=5432;Database=plain_app;Username=postgres;Password=postgres"
+  },
+  "Jwt": {
+    "Key": "dev-only-eval-signing-key-change-me-0123456789abcdef",
+    "Issuer": "plain-app",
+    "Audience": "plain-app",
+    "TestUser": "admin",
+    "TestPassword": "admin"
+  }
+}

--- a/tools/agent-evals/fixtures/plain-app/global.json
+++ b/tools/agent-evals/fixtures/plain-app/global.json
@@ -1,0 +1,3 @@
+{
+  "sdk": { "version": "9.0.313", "rollForward": "latestFeature" }
+}

--- a/tools/agent-evals/lib/fs-utils.mjs
+++ b/tools/agent-evals/lib/fs-utils.mjs
@@ -1,9 +1,31 @@
-import { cpSync, mkdirSync, existsSync } from 'node:fs';
+import { cpSync, mkdirSync, existsSync, readdirSync } from 'node:fs';
+import { join, relative } from 'node:path';
 
 // Recursively copy src into dst, merging onto any existing dst contents (used both to
 // seed a fixture and to overlay an oracle patch).
-export function copyDir(src, dst) {
+export function copyDir(src, dst, { filter } = {}) {
   if (!existsSync(src)) throw new Error(`copyDir: source missing: ${src}`);
   mkdirSync(dst, { recursive: true });
-  cpSync(src, dst, { recursive: true });
+  cpSync(src, dst, { recursive: true, filter });
+}
+
+// Build output / dependency dirs — never "source the build produced"; skipped by walkFiles.
+export const BUILD_ARTIFACT_DIRS = new Set(['bin', 'obj', 'node_modules', '.git', '.angular', 'dist', '.vs']);
+
+// Recursively list source files under `root` as sorted, POSIX-relative paths, skipping
+// BUILD_ARTIFACT_DIRS. Unreadable dirs are skipped (not thrown). Used to capture what a build
+// produced — e.g. the showcase file-tree + count.
+export function walkFiles(root, dir = root, out = []) {
+  let entries = [];
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) {
+      if (BUILD_ARTIFACT_DIRS.has(e.name)) continue;
+      walkFiles(root, full, out);
+    } else {
+      out.push(relative(root, full).split('\\').join('/'));
+    }
+  }
+  return out.sort();
 }

--- a/tools/agent-evals/lib/fs-utils.mjs
+++ b/tools/agent-evals/lib/fs-utils.mjs
@@ -12,6 +12,15 @@ export function copyDir(src, dst, { filter } = {}) {
 // Build output / dependency dirs — never "source the build produced"; skipped by walkFiles.
 export const BUILD_ARTIFACT_DIRS = new Set(['bin', 'obj', 'node_modules', '.git', '.angular', 'dist', '.vs']);
 
+// A cpSync `filter` that drops any path lying under one of `dirNames` (matched as a path segment), so
+// a whole build-artifact subtree is excluded from a copyDir. Pass a subset of BUILD_ARTIFACT_DIRS —
+// the full set, or the set minus 'node_modules' to keep a shipped bundle. Single source of truth for
+// "what's a build dir", shared with walkFiles instead of per-track regexes.
+export function skipDirsFilter(dirNames) {
+  const set = dirNames instanceof Set ? dirNames : new Set(dirNames);
+  return (src) => !src.split(/[\\/]/).some((seg) => set.has(seg));
+}
+
 // Recursively list source files under `root` as sorted, POSIX-relative paths, skipping
 // BUILD_ARTIFACT_DIRS. Unreadable dirs are skipped (not thrown). Used to capture what a build
 // produced — e.g. the showcase file-tree + count.

--- a/tools/agent-evals/lib/fs-utils.test.mjs
+++ b/tools/agent-evals/lib/fs-utils.test.mjs
@@ -1,0 +1,24 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { walkFiles } from './fs-utils.mjs';
+
+test('walkFiles lists source files as sorted POSIX paths and skips build output / deps', () => {
+  const root = mkdtempSync(join(tmpdir(), 'fsu-'));
+  mkdirSync(join(root, 'Backend', 'Entities'), { recursive: true });
+  mkdirSync(join(root, 'node_modules', 'left-pad'), { recursive: true });
+  mkdirSync(join(root, 'Backend', 'bin'), { recursive: true });
+  writeFileSync(join(root, 'Backend', 'Entities', 'Product.cs'), 'class Product {}');
+  writeFileSync(join(root, 'README.md'), '# app');
+  writeFileSync(join(root, 'node_modules', 'left-pad', 'index.js'), 'module.exports={}');
+  writeFileSync(join(root, 'Backend', 'bin', 'app.dll'), 'binary');
+
+  assert.deepEqual(walkFiles(root), ['Backend/Entities/Product.cs', 'README.md']);
+});
+
+test('walkFiles returns [] for an empty directory', () => {
+  const root = mkdtempSync(join(tmpdir(), 'fsu-'));
+  assert.deepEqual(walkFiles(root), []);
+});

--- a/tools/agent-evals/oracle/supplier-crud/Backend/Controllers/SuppliersController.cs
+++ b/tools/agent-evals/oracle/supplier-crud/Backend/Controllers/SuppliersController.cs
@@ -1,0 +1,55 @@
+using Backend.Data;
+using Backend.Entities;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Controllers;
+
+// Oracle (known-good) CRUD for Supplier. [ApiController] auto-returns 400 on an invalid model
+// (Name/Email), so an invalid create/update never persists. [Authorize] requires authentication.
+[ApiController]
+[Authorize]
+[Route("api/[controller]")]
+public class SuppliersController(AppDbContext db) : ControllerBase
+{
+    [HttpGet]
+    public async Task<ActionResult<IEnumerable<Supplier>>> GetAll()
+        => await db.Suppliers.ToListAsync();
+
+    [HttpGet("{id:int}")]
+    public async Task<ActionResult<Supplier>> GetById(int id)
+    {
+        var supplier = await db.Suppliers.FindAsync(id);
+        return supplier is null ? NotFound() : supplier;
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<Supplier>> Create(Supplier supplier)
+    {
+        db.Suppliers.Add(supplier);
+        await db.SaveChangesAsync();
+        return CreatedAtAction(nameof(GetById), new { id = supplier.Id }, supplier);
+    }
+
+    [HttpPut("{id:int}")]
+    public async Task<IActionResult> Update(int id, Supplier input)
+    {
+        var supplier = await db.Suppliers.FindAsync(id);
+        if (supplier is null) return NotFound();
+        supplier.Name = input.Name;
+        supplier.Email = input.Email;
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpDelete("{id:int}")]
+    public async Task<IActionResult> Delete(int id)
+    {
+        var supplier = await db.Suppliers.FindAsync(id);
+        if (supplier is null) return NotFound();
+        db.Suppliers.Remove(supplier);
+        await db.SaveChangesAsync();
+        return NoContent();
+    }
+}

--- a/tools/agent-evals/oracle/supplier-crud/Backend/Data/AppDbContext.cs
+++ b/tools/agent-evals/oracle/supplier-crud/Backend/Data/AppDbContext.cs
@@ -1,0 +1,12 @@
+using Backend.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Backend.Data;
+
+// Oracle overlay: extends the thin baseline context with the Supplier set.
+public class AppDbContext : DbContext
+{
+    public AppDbContext(DbContextOptions<AppDbContext> options) : base(options) { }
+
+    public DbSet<Supplier> Suppliers => Set<Supplier>();
+}

--- a/tools/agent-evals/oracle/supplier-crud/Backend/Entities/Supplier.cs
+++ b/tools/agent-evals/oracle/supplier-crud/Backend/Entities/Supplier.cs
@@ -1,0 +1,18 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Backend.Entities;
+
+// Oracle (known-good) solution for the supplier-crud task on the plain-.NET baseline. Doubles as
+// living documentation of the intended plain-arm solution.
+public class Supplier
+{
+    public int Id { get; set; }
+
+    [Required]
+    [MaxLength(100)]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [EmailAddress]
+    public string Email { get; set; } = string.Empty;
+}

--- a/tools/agent-evals/showcase.mjs
+++ b/tools/agent-evals/showcase.mjs
@@ -1,0 +1,102 @@
+#!/usr/bin/env node
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { resultsRoot } from './lib/paths.mjs';
+import { walkFiles } from './lib/fs-utils.mjs';
+import claude from './agents/claude.mjs';
+import codex from './agents/codex.mjs';
+import noop from './agents/noop.mjs';
+import { provision as provisionPlain } from './tracks/plain.mjs';
+import { provision as provisionNative } from './tracks/native.mjs';
+
+// Showcase orchestrator — the UNSCORED demo-video sibling of the scored eval (cli.mjs).
+// Runs {claude} × {spiderly, plain} (codex deferred for the first cut) as freestyle whole-app builds from a one-line
+// prompt, then records each built workspace + metrics + file tree for the video (HUD + file-tree
+// bloom). No pass/fail, no verify.mjs, no reps — see the showcase-track design section in
+// docs/superpowers/specs/2026-06-14-agent-eval-harness-design.md.
+//
+// spiderly vs plain differ by provisioning (see PROVISION below) and by whether the Spiderly
+// toolchain is on PATH for the spiderly cell (CLI + packages, so `spiderly init` works) — the
+// caller's job (locally: an installed CLI; in CI: the agent-evals.yml build+publish).
+
+const agentsByName = { claude, codex, noop };
+
+// Named domain (vs a bare "make the app") so all four builds share a comparable entity and the
+// walkthrough + recap grid are meaningful. The two phrasings are the locked showcase prompts.
+const DOMAIN = 'product-catalog admin panel';
+const PROMPTS = {
+  spiderly: `Make a ${DOMAIN} with Spiderly.`,
+  plain: `Make a ${DOMAIN}.`,
+};
+const SIDES = ['spiderly', 'plain'];
+
+// Per-side provisioning: the spiderly cell gets the real Claude+Spiderly guidance (native track —
+// AGENTS.md docs pointer + .claude/skills); the plain cell gets a bare workspace (no framework).
+// The agent does its own scaffolding either way (`spiderly init` vs `dotnet new` / `ng new`).
+const PROVISION = { spiderly: provisionNative, plain: provisionPlain };
+
+// A whole-app build needs far more turns than an atomic task. codex ignores maxTurns (no exec flag);
+// claude honours it. NOTE: the adapters' hard 20-min wall-clock timeout is the likely binding limit
+// for a full freestyle build — making that configurable is a known follow-up once a first real run
+// shows whether it truncates.
+const SHOWCASE_MAX_TURNS = 200;
+
+export { PROMPTS };
+
+function parseArgs(argv) {
+  // Codex is deferred for the first cut — default to Claude only. Pass `--agents claude,codex`
+  // (once codex is re-auth'd) to run the full 2×2.
+  const a = { agents: ['claude'], sides: [...SIDES] };
+  for (let i = 0; i < argv.length; i++) {
+    const k = argv[i].startsWith('--') ? argv[i].slice(2) : null;
+    const v = argv[i + 1];
+    if (!k || v === undefined || v.startsWith('--')) { console.error(`showcase: bad arg near ${argv[i]}`); process.exit(1); }
+    if (k === 'agents') { a.agents = v.split(',').filter(Boolean); i++; }
+    else if (k === 'sides') { a.sides = v.split(',').filter(Boolean); i++; }
+    else { console.error(`showcase: unknown flag --${k}`); process.exit(1); }
+  }
+  return a;
+}
+
+// Only orchestrate when run directly (`node showcase.mjs ...`) — importing for tests must not run it.
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  const { agents, sides } = parseArgs(process.argv.slice(2));
+  const runId = new Date().toISOString().replace(/[:.]/g, '-');
+  const root = join(resultsRoot, `showcase-${runId}`);
+  const cells = [];
+
+  for (const agentName of agents) {
+    const adapter = agentsByName[agentName];
+    if (!adapter) { console.error(`showcase: unknown agent "${agentName}"`); process.exit(1); }
+    for (const side of sides) {
+      const prompt = PROMPTS[side];
+      if (!prompt) { console.error(`showcase: unknown side "${side}"`); process.exit(1); }
+      const ws = join(root, 'ws', `${agentName}-${side}`);
+      mkdirSync(ws, { recursive: true });
+      PROVISION[side]({ fixture: 'showcase-empty' }, ws); // spiderly→native guidance, plain→bare
+
+      console.log(`[showcase] ${agentName} × ${side} — building…`);
+      let meta = { tokens: 0, turns: 0, wallMs: 0, cleanExit: false, costUsd: 0 };
+      let transcript = '';
+      let error = null;
+      try {
+        const r = await adapter.run({ task: { id: `${agentName}-${side}` }, workspaceDir: ws, prompt, maxTurns: SHOWCASE_MAX_TURNS });
+        meta = { tokens: r.tokens ?? 0, turns: r.turns ?? 0, wallMs: r.wallMs ?? 0, cleanExit: !!r.cleanExit, costUsd: r.costUsd ?? 0 };
+        transcript = r.transcript ?? '';
+      } catch (err) {
+        error = String(err?.message ?? err);
+      }
+
+      const files = walkFiles(ws);
+      writeFileSync(join(root, `${agentName}-${side}.transcript.txt`), transcript);
+      cells.push({ agent: agentName, side, prompt, ...meta, fileCount: files.length, files, error });
+      console.log(`[showcase] ${agentName} × ${side} — ${error ? `ERROR: ${error}` : `${files.length} files · ${meta.turns} turns · ${(meta.wallMs / 1000).toFixed(0)}s`}`);
+    }
+  }
+
+  writeFileSync(join(root, 'showcase.json'), JSON.stringify({ runId, cells }, null, 2));
+  // ws/ holds full built apps (large — gitignore-worthy); showcase.json is the small artifact the
+  // video pipeline reads for the HUD/bloom, and ws/ is what gets booted + recorded.
+  console.log(`\n[showcase] wrote ${join(root, 'showcase.json')} — ${cells.length} cells`);
+}

--- a/tools/agent-evals/showcase.test.mjs
+++ b/tools/agent-evals/showcase.test.mjs
@@ -1,0 +1,10 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { PROMPTS } from './showcase.mjs';
+
+test('PROMPTS name the domain and only the spiderly side mentions Spiderly', () => {
+  assert.match(PROMPTS.spiderly, /product-catalog admin panel/);
+  assert.match(PROMPTS.plain, /product-catalog admin panel/);
+  assert.match(PROMPTS.spiderly, /with Spiderly/i);
+  assert.doesNotMatch(PROMPTS.plain, /spiderly/i);
+});

--- a/tools/agent-evals/tasks-loader.mjs
+++ b/tools/agent-evals/tasks-loader.mjs
@@ -6,7 +6,7 @@ const TIERS = ['atomic', 'feature', 'full-app'];
 const REQUIRED_FIELDS = ['id', 'tier', 'targets', 'fixture', 'maxTurns', 'required'];
 
 // Discover tasks. A task is a folder under tasks/<tier>/ containing task.json + prompt.md.
-export function loadTasks({ tier } = {}) {
+export function loadTasks({ tier, taskId } = {}) {
   const tasks = [];
   for (const t of TIERS) {
     if (tier && tier !== t) continue;
@@ -14,6 +14,7 @@ export function loadTasks({ tier } = {}) {
     if (!existsSync(tierDir)) continue;
     for (const d of readdirSync(tierDir, { withFileTypes: true })) {
       if (!d.isDirectory()) continue;
+      if (taskId && d.name !== taskId) continue;
       const dir = join(tierDir, d.name);
       if (!existsSync(join(dir, 'task.json'))) continue;
       const meta = JSON.parse(readFileSync(join(dir, 'task.json'), 'utf8'));

--- a/tools/agent-evals/tasks/atomic/supplier-crud/prompt.md
+++ b/tools/agent-evals/tasks/atomic/supplier-crud/prompt.md
@@ -1,0 +1,12 @@
+Add a "Supplier" resource to this application's backend.
+
+A supplier has:
+- `Name` — text, required, at most 100 characters.
+- `Email` — text, required, must be a valid email address.
+
+Expose REST endpoints under `/api/suppliers` to create a supplier, get one by id, list all,
+update one, and delete one. Persist suppliers in the application's database (add whatever entity,
+mapping, and migration are needed). A create or update request with an invalid Name or Email must
+be rejected with HTTP 400 and must not persist anything. The endpoints must require authentication.
+
+Use the application's existing stack and conventions. Do not introduce a new web framework.

--- a/tools/agent-evals/tasks/atomic/supplier-crud/task.json
+++ b/tools/agent-evals/tasks/atomic/supplier-crud/task.json
@@ -1,0 +1,8 @@
+{
+  "id": "supplier-crud",
+  "tier": "atomic",
+  "targets": ["entity", "validation", "crud-api"],
+  "fixture": "plain-app",
+  "maxTurns": 25,
+  "required": ["compiles", "supplier-entity", "suppliers-endpoint"]
+}

--- a/tools/agent-evals/tasks/atomic/supplier-crud/verify.mjs
+++ b/tools/agent-evals/tasks/atomic/supplier-crud/verify.mjs
@@ -1,5 +1,6 @@
-import { readdirSync, readFileSync } from 'node:fs';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { walkFiles } from '../../../lib/fs-utils.mjs';
 
 // INTERIM verifier (walking skeleton). The REAL check is OUTSIDE-IN — boot the app + Postgres, log
 // in, POST/GET /api/suppliers, assert 201/200 and a 400 on an invalid Name/Email — which is the
@@ -8,21 +9,6 @@ import { join } from 'node:path';
 // entity and a SuppliersController. Replace with the boot-based contract check once Postgres is
 // wired. Per the runVerify INVARIANT, never throw — return failing checks instead.
 
-function csFiles(dir) {
-  const out = [];
-  let entries = [];
-  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
-  for (const e of entries) {
-    if (e.isDirectory()) {
-      if (e.name === 'bin' || e.name === 'obj' || e.name === 'node_modules') continue;
-      out.push(...csFiles(join(dir, e.name)));
-    } else if (e.name.endsWith('.cs')) {
-      out.push(join(dir, e.name));
-    }
-  }
-  return out;
-}
-
 export default async function verify({ workspaceDir, run }) {
   const backend = join(workspaceDir, 'Backend');
   const build = run('dotnet', ['build'], { cwd: backend, shell: true, timeoutMs: 10 * 60 * 1000 });
@@ -30,8 +16,10 @@ export default async function verify({ workspaceDir, run }) {
 
   let entity = false;
   let endpoint = false;
-  for (const f of csFiles(backend)) {
-    const txt = readFileSync(f, 'utf8');
+  // Reuse the shared tree-walk (skips bin/obj/node_modules/etc. via BUILD_ARTIFACT_DIRS); grep .cs only.
+  for (const rel of walkFiles(backend)) {
+    if (!rel.endsWith('.cs')) continue;
+    const txt = readFileSync(join(backend, rel), 'utf8');
     if (/class\s+Supplier\b/.test(txt) && /\bstring\s+Name\b/.test(txt)) entity = true;
     if (/class\s+SuppliersController\b/.test(txt)) endpoint = true;
     if (entity && endpoint) break;

--- a/tools/agent-evals/tasks/atomic/supplier-crud/verify.mjs
+++ b/tools/agent-evals/tasks/atomic/supplier-crud/verify.mjs
@@ -1,0 +1,45 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// INTERIM verifier (walking skeleton). The REAL check is OUTSIDE-IN — boot the app + Postgres, log
+// in, POST/GET /api/suppliers, assert 201/200 and a 400 on an invalid Name/Email — which is the
+// next infra step (it needs the app to run). Until then this discriminates oracle (feature present,
+// builds) from no-op (nothing) WITHOUT a database: `dotnet build` plus the presence of a Supplier
+// entity and a SuppliersController. Replace with the boot-based contract check once Postgres is
+// wired. Per the runVerify INVARIANT, never throw — return failing checks instead.
+
+function csFiles(dir) {
+  const out = [];
+  let entries = [];
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return out; }
+  for (const e of entries) {
+    if (e.isDirectory()) {
+      if (e.name === 'bin' || e.name === 'obj' || e.name === 'node_modules') continue;
+      out.push(...csFiles(join(dir, e.name)));
+    } else if (e.name.endsWith('.cs')) {
+      out.push(join(dir, e.name));
+    }
+  }
+  return out;
+}
+
+export default async function verify({ workspaceDir, run }) {
+  const backend = join(workspaceDir, 'Backend');
+  const build = run('dotnet', ['build'], { cwd: backend, shell: true, timeoutMs: 10 * 60 * 1000 });
+  const compiles = build.code === 0;
+
+  let entity = false;
+  let endpoint = false;
+  for (const f of csFiles(backend)) {
+    const txt = readFileSync(f, 'utf8');
+    if (/class\s+Supplier\b/.test(txt) && /\bstring\s+Name\b/.test(txt)) entity = true;
+    if (/class\s+SuppliersController\b/.test(txt)) endpoint = true;
+    if (entity && endpoint) break;
+  }
+
+  return [
+    { name: 'compiles', pass: compiles, detail: compiles ? 'dotnet build OK' : build.stderr.slice(-800) },
+    { name: 'supplier-entity', pass: entity, detail: entity ? 'found a Supplier entity with a string Name' : 'no Supplier entity with a string Name property' },
+    { name: 'suppliers-endpoint', pass: endpoint, detail: endpoint ? 'found a SuppliersController' : 'no SuppliersController' },
+  ];
+}

--- a/tools/agent-evals/tracks/agnostic.mjs
+++ b/tools/agent-evals/tracks/agnostic.mjs
@@ -1,23 +1,30 @@
-import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { existsSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { copyDir } from '../lib/fs-utils.mjs';
 import { fixturesRoot, bundleRoot } from '../lib/paths.mjs';
 
-// Agnostic track: every agent gets ONLY the AGENTS.md index built from the shipped
-// bundle's `doc`-surface entries — no agent-specific layer (no skill junctions, no
-// .cursor/rules). bundlePath is injectable for testing.
+// Agnostic track: every agent gets the shipped bundle's reference DOCS (the doc-surface skills under
+// agent/docs/) and no agent-specific layer (no skill junctions, no .cursor/rules). This mirrors what
+// `Spiderly.CLI agent-sync` projects into a real consumer: the version-matched docs/ folder plus an
+// AGENTS.md POINTER telling the agent to browse it. The bundle manifest lists ONLY skill-surface
+// entries (see build-agent-bundle.mjs), so the docs come from the docs/ folder — never the manifest
+// (filtering surface==='doc' out of the manifest finds nothing). bundlePath is injectable for tests.
 export function provision(task, workspaceDir, { bundlePath = bundleRoot } = {}) {
   copyDir(join(fixturesRoot, task.fixture), workspaceDir);
 
-  const manifestPath = join(bundlePath, 'manifest.json');
-  if (!existsSync(manifestPath)) return; // no bundle (e.g. trivial self-test) → fixture only
+  const docsSrc = join(bundlePath, 'docs');
+  if (!existsSync(docsSrc)) return; // no bundle docs (e.g. the trivial self-test bundle) → fixture only
 
-  const skills = JSON.parse(readFileSync(manifestPath, 'utf8')).skills ?? [];
-  const docs = skills.filter((s) => s.surface === 'doc');
-  const index = [
-    '# Spiderly agent guidance (agnostic track)',
-    '',
-    ...docs.map((d) => `- **${d.name}** — ${d.description}`),
-  ].join('\n');
-  writeFileSync(join(workspaceDir, 'AGENTS.md'), index + '\n');
+  copyDir(docsSrc, join(workspaceDir, 'docs'));
+  writeFileSync(join(workspaceDir, 'AGENTS.md'), AGENTS_POINTER);
 }
+
+// Mirrors AgentSyncCommand.BuildBlock — a static pointer to docs/, not an enumerated index.
+const AGENTS_POINTER = [
+  '# Spiderly',
+  '',
+  'Your training data for Spiderly is stale. Before writing any Spiderly code, browse `docs/` and',
+  'read the `SKILL.md` for the topic you are working on — these docs are version-matched to the',
+  'Spiderly package under test.',
+  '',
+].join('\n');

--- a/tools/agent-evals/tracks/agnostic.test.mjs
+++ b/tools/agent-evals/tracks/agnostic.test.mjs
@@ -5,21 +5,27 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { provision } from './agnostic.mjs';
 
-test('agnostic provision copies the fixture and writes an AGENTS.md index of doc surfaces only', () => {
-  // Fake bundle with one doc + one skill surface.
+test('agnostic provision copies the bundled docs into the workspace and writes an AGENTS.md pointer', () => {
+  // Realistic bundle shape (mirrors build-agent-bundle.mjs): doc-surface skills are FOLDERS under
+  // docs/, and manifest.json lists ONLY skill-surface entries. So filtering docs out of the manifest
+  // (the old bug) finds nothing — the docs must come from the docs/ folder, like agent-sync does.
   const bundle = mkdtempSync(join(tmpdir(), 'bundle-'));
+  mkdirSync(join(bundle, 'docs', 'entity-design'), { recursive: true });
+  writeFileSync(join(bundle, 'docs', 'entity-design', 'SKILL.md'), '# Entity design\n');
+  mkdirSync(join(bundle, 'skills', 'deployment'), { recursive: true });
   writeFileSync(join(bundle, 'manifest.json'), JSON.stringify({
-    skills: [
-      { name: 'entity-design', surface: 'doc', description: 'Design entities.' },
-      { name: 'deployment', surface: 'skill', description: 'Deploy the app.' },
-    ],
+    skills: [{ name: 'deployment', surface: 'skill', description: 'Deploy the app.' }],
   }));
+
   const ws = mkdtempSync(join(tmpdir(), 'ws-'));
-  // task.fixture 'trivial' resolves under the harness fixturesRoot (exists from Task 1).
+  // task.fixture 'trivial' resolves under the harness fixturesRoot.
   provision({ fixture: 'trivial' }, ws, { bundlePath: bundle });
 
   assert.ok(existsSync(join(ws, 'README.md')), 'fixture file copied');
+  // The doc reaches the workspace as a browsable file, and AGENTS.md points at docs/ (agent-sync style).
+  assert.ok(existsSync(join(ws, 'docs', 'entity-design', 'SKILL.md')), 'bundled doc copied into workspace');
   const agents = readFileSync(join(ws, 'AGENTS.md'), 'utf8');
-  assert.match(agents, /entity-design/, 'doc surface listed');
-  assert.doesNotMatch(agents, /deployment/, 'skill surface must NOT be in the agnostic index');
+  assert.match(agents, /docs\//, 'AGENTS.md points at the docs directory');
+  // Skill-surface entries are NOT delivered by the docs-only agnostic track.
+  assert.doesNotMatch(agents, /deployment/, 'skill surface must NOT be in the agnostic guidance');
 });

--- a/tools/agent-evals/tracks/native.mjs
+++ b/tools/agent-evals/tracks/native.mjs
@@ -1,0 +1,62 @@
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { copyDir } from '../lib/fs-utils.mjs';
+import { fixturesRoot, bundleRoot } from '../lib/paths.mjs';
+
+// Native (Claude) track — reproduces what `Spiderly.CLI agent-sync` projects into a real consumer
+// (Spiderly.CLI/Commands/AgentSyncCommand.cs), but from the repo bundle and via COPIES: a pre-`init`
+// showcase workspace has no node_modules to junction against. It:
+//   • copies the bundle's docs/ into the workspace (browsable, version-matched)
+//   • writes AGENTS.md with agent-sync's exact "training data is stale → browse docs/" pointer block
+//   • copies each skill-surface skill into .claude/skills/spiderly-<name> (agent-sync junctions these)
+//   • makes CLAUDE.md import AGENTS.md (@AGENTS.md)
+// This is the honest "with Spiderly" showcase condition: the agent starts with the same Spiderly
+// guidance a real Claude Code user has.
+//
+// NOTE: native and agnostic.mjs both follow agent-sync's docs-pointer model; native is kept separate
+// because it ALSO copies the skill surfaces into .claude/skills and adds the CLAUDE.md import (the
+// native delta), and stages docs under a namespaced .spiderly/agent/docs so they can't collide with
+// files the freestyle build creates. agent-sync (AgentSyncCommand.cs) is the source of truth.
+
+const DOCS_SUBDIR = '.spiderly/agent/docs'; // where browsable docs are staged in the workspace
+
+// Verbatim from AgentSyncCommand.BuildBlock so the agent sees exactly the real pointer.
+function buildAgentsBlock(relDocs) {
+  return `<!-- BEGIN:spiderly -->
+# Spiderly
+
+Your training data for Spiderly is stale. Before writing any Spiderly code, browse
+\`${relDocs}/\` and read the \`SKILL.md\` for the topic you're working on — these docs are
+version-matched to the installed Spiderly package.
+<!-- END:spiderly -->
+`;
+}
+
+export function provision(task, workspaceDir, { bundlePath = bundleRoot } = {}) {
+  const fixtureDir = join(fixturesRoot, task.fixture);
+  if (existsSync(fixtureDir)) copyDir(fixtureDir, workspaceDir);
+
+  const manifestPath = join(bundlePath, 'manifest.json');
+  if (!existsSync(manifestPath)) return; // no bundle (e.g. a unit test) → fixture only
+
+  // Docs: stage them in the workspace and point AGENTS.md at them (mirrors agent-sync's relDocs).
+  const docsSrc = join(bundlePath, 'docs');
+  if (existsSync(docsSrc)) {
+    copyDir(docsSrc, join(workspaceDir, DOCS_SUBDIR));
+    writeFileSync(join(workspaceDir, 'AGENTS.md'), buildAgentsBlock(DOCS_SUBDIR));
+  }
+
+  // CLAUDE.md imports AGENTS.md (agent-sync's @AGENTS.md directive), preserving any existing content.
+  const claudePath = join(workspaceDir, 'CLAUDE.md');
+  const claudeExisting = existsSync(claudePath) ? readFileSync(claudePath, 'utf8') : '';
+  if (!claudeExisting.includes('@AGENTS.md')) {
+    writeFileSync(claudePath, '@AGENTS.md\n' + (claudeExisting ? '\n' + claudeExisting : ''));
+  }
+
+  // Skill surfaces: copy each into .claude/skills/spiderly-<name> (agent-sync junctions these).
+  const skills = JSON.parse(readFileSync(manifestPath, 'utf8')).skills ?? [];
+  for (const s of skills) {
+    const skillSrc = join(bundlePath, 'skills', s.name);
+    if (existsSync(skillSrc)) copyDir(skillSrc, join(workspaceDir, '.claude', 'skills', `spiderly-${s.name}`));
+  }
+}

--- a/tools/agent-evals/tracks/native.test.mjs
+++ b/tools/agent-evals/tracks/native.test.mjs
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { provision } from './native.mjs';
+
+// Build a fake bundle mirroring the real layout: skill-surface-only manifest + docs/ + skills/.
+function fakeBundle() {
+  const bundle = mkdtempSync(join(tmpdir(), 'bundle-'));
+  mkdirSync(join(bundle, 'docs', 'entity-design'), { recursive: true });
+  writeFileSync(join(bundle, 'docs', 'entity-design', 'SKILL.md'), '# entity design');
+  mkdirSync(join(bundle, 'skills', 'add-entity'), { recursive: true });
+  writeFileSync(join(bundle, 'skills', 'add-entity', 'SKILL.md'), '# add entity');
+  writeFileSync(join(bundle, 'manifest.json'), JSON.stringify({
+    skills: [{ name: 'add-entity', surface: 'skill', description: 'Scaffold an entity.' }],
+  }));
+  return bundle;
+}
+
+test('native provision reproduces agent-sync: docs pointer, junctioned skills, CLAUDE import', () => {
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  provision({ fixture: 'trivial' }, ws, { bundlePath: fakeBundle() });
+
+  assert.ok(existsSync(join(ws, 'README.md')), 'fixture file copied');
+
+  const agents = readFileSync(join(ws, 'AGENTS.md'), 'utf8');
+  assert.match(agents, /<!-- BEGIN:spiderly -->/, 'agent-sync marker block present');
+  assert.match(agents, /training data for Spiderly is stale/, 'verbatim pointer text');
+  assert.match(agents, /\.spiderly\/agent\/docs\//, 'points at the staged docs dir');
+
+  assert.ok(existsSync(join(ws, '.spiderly', 'agent', 'docs', 'entity-design', 'SKILL.md')), 'docs staged');
+  assert.ok(existsSync(join(ws, '.claude', 'skills', 'spiderly-add-entity', 'SKILL.md')), 'skill copied with spiderly- prefix');
+
+  const claude = readFileSync(join(ws, 'CLAUDE.md'), 'utf8');
+  assert.match(claude, /@AGENTS\.md/, 'CLAUDE.md imports AGENTS.md');
+});
+
+test('native provision without a bundle falls back to fixture-only (no throw)', () => {
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  const emptyBundle = mkdtempSync(join(tmpdir(), 'nobundle-'));
+  provision({ fixture: 'trivial' }, ws, { bundlePath: emptyBundle }); // no manifest.json
+  assert.ok(existsSync(join(ws, 'README.md')), 'fixture still copied');
+  assert.equal(existsSync(join(ws, 'AGENTS.md')), false, 'no AGENTS.md without a bundle');
+});

--- a/tools/agent-evals/tracks/plain-net.mjs
+++ b/tools/agent-evals/tracks/plain-net.mjs
@@ -1,0 +1,14 @@
+import { join } from 'node:path';
+import { copyDir } from '../lib/fs-utils.mjs';
+import { fixturesRoot } from '../lib/paths.mjs';
+
+// Benchmark plain (no-Spiderly) track — DISTINCT from the showcase `plain` track, which provisions a
+// BARE workspace for freestyle "make the app" builds. The SCORED benchmark instead starts the plain
+// arm from the frozen thin plain-.NET baseline (auth + EF, no entity) so runs are repeatable and the
+// agent only does per-feature work. The TRACK owns the starter (it ignores task.fixture); no Spiderly
+// guidance is written. Build output is never provisioned. `root`/`fixtureName` injectable for tests.
+const SKIP = /[\\/](bin|obj|node_modules)([\\/]|$)/;
+
+export function provision(task, workspaceDir, { fixtureName = 'plain-app', root = fixturesRoot } = {}) {
+  copyDir(join(root, fixtureName), workspaceDir, { filter: (src) => !SKIP.test(src) });
+}

--- a/tools/agent-evals/tracks/plain-net.mjs
+++ b/tools/agent-evals/tracks/plain-net.mjs
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { copyDir } from '../lib/fs-utils.mjs';
+import { copyDir, skipDirsFilter, BUILD_ARTIFACT_DIRS } from '../lib/fs-utils.mjs';
 import { fixturesRoot } from '../lib/paths.mjs';
 
 // Benchmark plain (no-Spiderly) track — DISTINCT from the showcase `plain` track, which provisions a
@@ -7,8 +7,7 @@ import { fixturesRoot } from '../lib/paths.mjs';
 // arm from the frozen thin plain-.NET baseline (auth + EF, no entity) so runs are repeatable and the
 // agent only does per-feature work. The TRACK owns the starter (it ignores task.fixture); no Spiderly
 // guidance is written. Build output is never provisioned. `root`/`fixtureName` injectable for tests.
-const SKIP = /[\\/](bin|obj|node_modules)([\\/]|$)/;
-
 export function provision(task, workspaceDir, { fixtureName = 'plain-app', root = fixturesRoot } = {}) {
-  copyDir(join(root, fixtureName), workspaceDir, { filter: (src) => !SKIP.test(src) });
+  // Skip every build artifact (the thin baseline ships no node_modules to keep anyway).
+  copyDir(join(root, fixtureName), workspaceDir, { filter: skipDirsFilter(BUILD_ARTIFACT_DIRS) });
 }

--- a/tools/agent-evals/tracks/plain-net.test.mjs
+++ b/tools/agent-evals/tracks/plain-net.test.mjs
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { provision } from './plain-net.mjs';
+
+test('plain-net provision copies the baseline source, skips build output, writes no AGENTS.md', () => {
+  // Fake fixtures root with a `plain-app` containing a source file AND a bin/ build artifact.
+  const root = mkdtempSync(join(tmpdir(), 'fix-'));
+  mkdirSync(join(root, 'plain-app', 'Backend', 'bin', 'Debug'), { recursive: true });
+  writeFileSync(join(root, 'plain-app', 'Backend', 'Program.cs'), '// baseline');
+  writeFileSync(join(root, 'plain-app', 'Backend', 'bin', 'Debug', 'Backend.dll'), 'BINARY');
+
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  provision({}, ws, { root });
+
+  assert.ok(existsSync(join(ws, 'Backend', 'Program.cs')), 'baseline source copied');
+  assert.equal(existsSync(join(ws, 'Backend', 'bin')), false, 'build output must NOT be provisioned');
+  assert.equal(existsSync(join(ws, 'AGENTS.md')), false, 'plain arm gets no Spiderly guidance');
+});

--- a/tools/agent-evals/tracks/plain.mjs
+++ b/tools/agent-evals/tracks/plain.mjs
@@ -1,0 +1,18 @@
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { copyDir } from '../lib/fs-utils.mjs';
+import { fixturesRoot } from '../lib/paths.mjs';
+
+// Plain track: the no-framework control. The agent gets ONLY the task's starting fixture —
+// for a freestyle showcase build that's an empty workspace — and NOTHING from Spiderly: no
+// init'd app, no AGENTS.md bundle, no junctioned skills. "Make the app" from a bare directory;
+// the agent runs its own `dotnet new` / `ng new`. The spiderly↔plain gap is the whole point of
+// the showcase, so this track must add nothing a Spiderly-aware track would.
+//
+// The fixture copy is guarded so a task can declare an absent/empty fixture and still get a bare
+// workspace (freestyle from nothing) rather than throwing.
+export function provision(task, workspaceDir) {
+  const fixtureDir = join(fixturesRoot, task.fixture);
+  if (existsSync(fixtureDir)) copyDir(fixtureDir, workspaceDir);
+  // Deliberately nothing else.
+}

--- a/tools/agent-evals/tracks/plain.test.mjs
+++ b/tools/agent-evals/tracks/plain.test.mjs
@@ -1,0 +1,21 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { provision } from './plain.mjs';
+
+test('plain provision copies the fixture but writes NO Spiderly guidance', () => {
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  // 'trivial' fixture exists under the harness fixturesRoot (used by the agnostic test too).
+  provision({ fixture: 'trivial' }, ws);
+  assert.ok(existsSync(join(ws, 'README.md')), 'fixture file copied');
+  // The defining invariant of the plain track: it must add nothing Spiderly-aware.
+  assert.equal(existsSync(join(ws, 'AGENTS.md')), false, 'plain track must not write an AGENTS.md');
+});
+
+test('plain provision tolerates an absent fixture (bare freestyle start)', () => {
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  provision({ fixture: 'does-not-exist' }, ws); // must not throw
+  assert.equal(existsSync(join(ws, 'AGENTS.md')), false);
+});

--- a/tools/agent-evals/tracks/spiderly.mjs
+++ b/tools/agent-evals/tracks/spiderly.mjs
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { copyDir } from '../lib/fs-utils.mjs';
+import { copyDir, skipDirsFilter, BUILD_ARTIFACT_DIRS } from '../lib/fs-utils.mjs';
 import { fixturesRoot } from '../lib/paths.mjs';
 
 // Spiderly (with-framework) benchmark arm. The fixture is a REAL `spiderly init` app, left intact:
@@ -10,9 +10,10 @@ import { fixturesRoot } from '../lib/paths.mjs';
 // mirroring plain-net. `root`/`fixtureName` injectable for tests.
 //
 // KEEP node_modules — that's where the shipped docs/skills live; stripping it is the very bug we just
-// fixed, one level up. Only .NET build artifacts (bin/obj) are skipped.
-const SKIP = /[\\/](bin|obj)([\\/]|$)/;
+// fixed, one level up. So skip the standard build artifacts MINUS node_modules: the keep-it invariant
+// is one data difference from the shared set, not a hand-retyped regex.
+const SKIP_DIRS = new Set([...BUILD_ARTIFACT_DIRS].filter((d) => d !== 'node_modules'));
 
 export function provision(task, workspaceDir, { fixtureName = 'spiderly-app', root = fixturesRoot } = {}) {
-  copyDir(join(root, fixtureName), workspaceDir, { filter: (src) => !SKIP.test(src) });
+  copyDir(join(root, fixtureName), workspaceDir, { filter: skipDirsFilter(SKIP_DIRS) });
 }

--- a/tools/agent-evals/tracks/spiderly.mjs
+++ b/tools/agent-evals/tracks/spiderly.mjs
@@ -1,0 +1,18 @@
+import { join } from 'node:path';
+import { copyDir } from '../lib/fs-utils.mjs';
+import { fixturesRoot } from '../lib/paths.mjs';
+
+// Spiderly (with-framework) benchmark arm. The fixture is a REAL `spiderly init` app, left intact:
+// its agent guidance — the root AGENTS.md, the docs under node_modules/spiderly/agent/docs, and the
+// .claude/skills/spiderly-* skills — is already there because `spiderly init` runs `agent-sync`. So
+// this track ADDS nothing and (unlike plain-net) STRIPS nothing but .NET build output: the agent
+// gets exactly what a real Spiderly developer has. The TRACK owns the starter (ignores task.fixture),
+// mirroring plain-net. `root`/`fixtureName` injectable for tests.
+//
+// KEEP node_modules — that's where the shipped docs/skills live; stripping it is the very bug we just
+// fixed, one level up. Only .NET build artifacts (bin/obj) are skipped.
+const SKIP = /[\\/](bin|obj)([\\/]|$)/;
+
+export function provision(task, workspaceDir, { fixtureName = 'spiderly-app', root = fixturesRoot } = {}) {
+  copyDir(join(root, fixtureName), workspaceDir, { filter: (src) => !SKIP.test(src) });
+}

--- a/tools/agent-evals/tracks/spiderly.test.mjs
+++ b/tools/agent-evals/tracks/spiderly.test.mjs
@@ -1,0 +1,31 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { provision } from './spiderly.mjs';
+
+test('spiderly provision copies the real init output incl. its shipped guidance, skips only build output', () => {
+  // Fake `spiderly init` app: app source + the guidance that init/agent-sync set up (root AGENTS.md
+  // and the docs shipped inside node_modules/spiderly/agent) + a .NET build artifact.
+  const root = mkdtempSync(join(tmpdir(), 'fix-'));
+  const app = join(root, 'spiderly-app');
+  mkdirSync(join(app, 'Backend', 'bin'), { recursive: true });
+  mkdirSync(join(app, 'node_modules', 'spiderly', 'agent', 'docs', 'entity-design'), { recursive: true });
+  writeFileSync(join(app, 'Backend', 'Program.cs'), '// spiderly app');
+  writeFileSync(join(app, 'AGENTS.md'), '# Spiderly\n');
+  writeFileSync(join(app, 'node_modules', 'spiderly', 'agent', 'docs', 'entity-design', 'SKILL.md'), '# doc');
+  writeFileSync(join(app, 'Backend', 'bin', 'x.dll'), 'BIN');
+
+  const ws = mkdtempSync(join(tmpdir(), 'ws-'));
+  provision({}, ws, { root });
+
+  assert.ok(existsSync(join(ws, 'Backend', 'Program.cs')), 'app source copied');
+  assert.ok(existsSync(join(ws, 'AGENTS.md')), 'init-written AGENTS.md kept');
+  // The whole point: the guidance shipped in node_modules is KEPT (plain-net strips it; this must not).
+  assert.ok(
+    existsSync(join(ws, 'node_modules', 'spiderly', 'agent', 'docs', 'entity-design', 'SKILL.md')),
+    'shipped Spiderly guidance kept',
+  );
+  assert.equal(existsSync(join(ws, 'Backend', 'bin')), false, '.NET build output skipped');
+});


### PR DESCRIPTION
Adds both arms of a "build the same feature with Spiderly vs plain .NET" benchmark to the agent-evals harness, plus showcase orchestrator scaffolding (separate effort, bundled in the first commit).

## What's here
- **Codex runner** (`agents/codex.mjs`) + a tested JSONL usage parser.
- **`plain-net` track** + thin plain-.NET baseline fixture (`fixtures/plain-app/`: .NET 9 API + EF + JWT, no entity).
- **`spiderly` track** = the real `spiderly init` app kept intact (guidance included).
- **Fix:** the `agnostic` track emitted an empty `AGENTS.md` (filtered docs from the skill-only manifest). Now copies `docs/` + writes the agent-sync-style pointer (mirrors `AgentSyncCommand`).
- **Neutral `supplier-crud` task** + interim verifier; plain arm validated end-to-end via the free oracle/noop agents.
- **Showcase scaffolding** (`showcase.mjs`, `native.mjs`, `plain.mjs`) — tested, not wired into any gate; the video pipeline is a separate effort.

## Not here yet (tracked in #274)
- Wiring the workflow to run both arms on `supplier-crud` + building the `plain-app` fixture in CI.
- Real outside-in boot verifier (Postgres) replacing the interim grep.
- Spiderly-side oracle patch.

Harness self-test: 24/24 green.
