### PR TITLE
ci(review): sync claude-review.yml skip-list to develop (unblock develop PR gate)

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -32,6 +32,6 @@ jobs:
 
         CONVENTIONS (advisory): public members in shipped packages (Spiderly.Shared, Spiderly.Security, Spiderly.Infrastructure) need /// <summary> XML docs; remove dead code left by deletions; reuse existing helpers instead of duplicating; logic errors; security.
 
-        SKIP: framework-metadata.json, any *.generated.md, Angular/projects/spiderly/agent/**, and anything under obj/, bin/, node_modules/, or .source/.
+        SKIP: framework-metadata.json, any *.generated.md, any *.verified.cs (Verify snapshot fixtures — review the generator that produces them, not the approved output), Angular/projects/spiderly/agent/**, and anything under obj/, bin/, node_modules/, or .source/.
     secrets:
       CLAUDE_CODE_OAUTH_TOKEN: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
## Why
`develop`'s `claude-review.yml` gained an `*.verified.cs` SKIP clause (commit `5d46f9cf`, 2026-06-20) that `main` never got. GitHub's Claude-app token exchange requires the running workflow to be **byte-identical to the default branch (`main`)** — so this 2-line drift returns `401 Workflow validation failed` for **every** PR into `develop`, the review never runs, no verdict is written, and `claude-gate` fails closed. (Diagnosed on #283, whose diff touches no workflow files yet still hit the wall.)

## What
Fast-forward `main`'s `claude-review.yml` to match `develop`'s (the single `*.verified.cs` skip-clause line). Now identical to `develop`.

## Effect
Restores the gate for **all** pending/future `develop` PRs — #283 and the Phase 2 skill PRs (#284).

## Merge note
This PR touches `.github/workflows/**`, so it **cannot pass `claude-review` itself** (same 401, per CLAUDE.md — confirmed on #271/#272). **Admin-merge:** `gh pr merge <n> --rebase --admin`.