### PR TITLE
Support PrimeIcons enum for generated side menu icons

### DIFF
--- a/Spiderly.CLI/Commands/AddNewEntityCommand.cs
+++ b/Spiderly.CLI/Commands/AddNewEntityCommand.cs
@@ -207,10 +207,15 @@ namespace Spiderly.CLI.Commands
             string menuItemToAdd = $$"""
                                 {
                                     label: this.translocoService.translate('{{entityName}}List'),
-                                    icon: 'pi pi-fw pi-list',
+                                    icon: PrimeIcons.LIST + ' pi-fw',
                                     routerLink: ['/{{kebabEntityName}}-list'],
                                 },
             """;
+
+            if (!layoutContent.Contains("from 'primeng/api'"))
+            {
+                layoutContent = "import { PrimeIcons } from 'primeng/api';\n" + layoutContent;
+            }
 
             string pattern = @"(this\.menu = \[\s*\{\s*items: \[)";
             Match match = Regex.Match(layoutContent, pattern, RegexOptions.Singleline);

--- a/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
+++ b/Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs
@@ -4074,6 +4074,7 @@ import { FormsModule } from '@angular/forms';
 import { SpiderlyLayoutComponent, SpiderlyMenuItem, SecurityPermissionCodes } from 'spiderly';
 import { CommonModule } from '@angular/common';
 import { PermissionCodes } from '../enums/enums.generated';
+import { PrimeIcons } from 'primeng/api';
 
 @Component({
     selector: 'layout',
@@ -4099,14 +4100,14 @@ export class LayoutComponent {
         this.menu = [
             {
                 items: [
-                    { 
-                        label: this.translocoService.translate('Home'), 
-                        icon: 'pi pi-fw pi-home', 
+                    {
+                        label: this.translocoService.translate('Home'),
+                        icon: PrimeIcons.HOME + ' pi-fw',
                         routerLink: [''],
                     },
                     {
                         label: this.translocoService.translate('Administration'),
-                        icon: 'pi pi-fw pi-cog',
+                        icon: PrimeIcons.COG + ' pi-fw',
                         hasPermission: (permissionCodes: string[]): boolean => {
                             return (
                                 permissionCodes?.includes(PermissionCodes.ReadUser) ||
@@ -4116,7 +4117,7 @@ export class LayoutComponent {
                         items: [
                             {
                                 label: this.translocoService.translate('UserList'),
-                                icon: 'pi pi-fw pi-user',
+                                icon: PrimeIcons.USER + ' pi-fw',
                                 routerLink: [`/${this.config.administrationSlug}/users`],
                                 hasPermission: (permissionCodes: string[]): boolean => {
                                     return (
@@ -4126,7 +4127,7 @@ export class LayoutComponent {
                             },
                             {
                                 label: this.translocoService.translate('RoleList'),
-                                icon: 'pi pi-fw pi-id-card',
+                                icon: PrimeIcons.ID_CARD + ' pi-fw',
                                 routerLink: [`/${this.config.administrationSlug}/roles`],
                                 hasPermission: (permissionCodes: string[]): boolean => {
                                     return (


### PR DESCRIPTION
Closes #56.

The CLI hardcoded icon class strings like 'pi pi-fw pi-home' in the generated layout component, and again in `spiderly add-new-entity` when it injects a new menu item. This switches them to PrimeNG's own PrimeIcons enum (e.g. PrimeIcons.HOME + ' pi-fw'), so generated apps get type safety and IDE autocomplete on icon names.

The resulting CSS classes are identical (pi, pi-fw, and the icon name) — only composed via the enum instead of a raw literal. AddNewEntityCommand also now adds the `import { PrimeIcons } from 'primeng/api';` import to the layout if it isn't already present.

- Spiderly.Shared/Helpers/NetAndAngularFilesGenerator.cs — generated layout uses PrimeIcons
- Spiderly.CLI/Commands/AddNewEntityCommand.cs — injected menu item uses PrimeIcons + ensures the import