### PR TITLE
Add generic saveResponseAsFile helper

### DIFF
--- a/Angular/projects/spiderly/agent/docs/angular-customization/references/helper-functions.generated.md
+++ b/Angular/projects/spiderly/agent/docs/angular-customization/references/helper-functions.generated.md
@@ -32,6 +32,7 @@ Reusable helpers exported from `helper-functions.ts`. Import the one you need in
 | `nameof(key1: any, key2?: any): any` |  |
 | `parseDateOnlyLocal(s: string): Date \| null` |  |
 | `pushAction(cols: Column[], action: Action)` |  |
+| `saveResponseAsFile(res: HttpResponse<Blob>, fallbackName: string): void` |  |
 | `selectedTab(tabs: SpiderlyTab[]): number` |  |
 | `singleOrDefault<T>(array: T[], predicate: (item: T) => boolean): T \| undefined` |  |
 | `splitPascalCase(input: string)` |  |

--- a/Angular/projects/spiderly/src/lib/services/helper-functions.ts
+++ b/Angular/projects/spiderly/src/lib/services/helper-functions.ts
@@ -221,13 +221,23 @@ export function isExcelFileType(mimeType: string): boolean {
   return false;
 }
 
+export function saveResponseAsFile(
+  res: HttpResponse<Blob>,
+  fallbackName: string,
+): void {
+  if (res?.body == null) {
+    return;
+  }
+  let fileName = getFileNameFromContentDisposition(res, fallbackName);
+  FileSaver.saveAs(res.body, decodeURIComponent(fileName));
+}
+
 export function exportListToExcel(
   exportListToExcelObservableMethod: (filter: Filter) => Observable<any>,
   filter: Filter,
 ) {
   exportListToExcelObservableMethod(filter).subscribe((res) => {
-    let fileName = getFileNameFromContentDisposition(res, 'ExcelExport.xlsx');
-    FileSaver.saveAs(res.body, decodeURIComponent(fileName));
+    saveResponseAsFile(res, 'ExcelExport.xlsx');
   });
 }
 

--- a/claude-plugins/skills/angular-customization/references/helper-functions.generated.md
+++ b/claude-plugins/skills/angular-customization/references/helper-functions.generated.md
@@ -32,6 +32,7 @@ Reusable helpers exported from `helper-functions.ts`. Import the one you need in
 | `nameof(key1: any, key2?: any): any` |  |
 | `parseDateOnlyLocal(s: string): Date \| null` |  |
 | `pushAction(cols: Column[], action: Action)` |  |
+| `saveResponseAsFile(res: HttpResponse<Blob>, fallbackName: string): void` |  |
 | `selectedTab(tabs: SpiderlyTab[]): number` |  |
 | `singleOrDefault<T>(array: T[], predicate: (item: T) => boolean): T \| undefined` |  |
 | `splitPascalCase(input: string)` |  |

--- a/framework-metadata.json
+++ b/framework-metadata.json
@@ -587,6 +587,10 @@
       "signature": "pushAction(cols: Column[], action: Action)"
     },
     {
+      "name": "saveResponseAsFile",
+      "signature": "saveResponseAsFile(res: HttpResponse<Blob>, fallbackName: string): void"
+    },
+    {
       "name": "selectedTab",
       "signature": "selectedTab(tabs: SpiderlyTab[]): number"
     },


### PR DESCRIPTION
Closes #293.

`exportListToExcel` was the only blob-download helper, and it hardcodes the Excel filename and subscribes to the observable itself, so there was no way to save an arbitrary blob `HttpResponse` as a file without re-implementing the Content-Disposition + saveAs contract at each call site.

This extracts that logic into an exported `saveResponseAsFile(res, fallbackName)` (a no-op when `res.body` is null) and has `exportListToExcel` call it. Consumers can now download any blob response while the filename/saveAs contract lives in one place.

- Angular/projects/spiderly/src/lib/services/helper-functions.ts — add `saveResponseAsFile`, reuse it in `exportListToExcel`

Exported automatically via the existing `export * from './lib/services/helper-functions'` barrel. Verified with `ng build spiderly` (clean).